### PR TITLE
중간 merge Request

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -16,3 +16,6 @@ COOKIE_SECRET=cookieSecret
 # SSL Configuration (development)
 DB_SSL=true
 DB_SSL_REJECT_UNAUTHORIZED=false
+
+# LoL season
+LOL_SEASON=2025

--- a/src/controllers/replay.controller.ts
+++ b/src/controllers/replay.controller.ts
@@ -18,11 +18,11 @@ export const createReplay = async (
     const fileData = req.body; 
 
     try {
-        const savedReplay = await replayService.save(fileData);
+        const savedReplay = await replayService.allSave(fileData);
         return res.status(201).json({
             status: 'success',
             message: 'Replay created successfully',
-            data: savedReplay
+            // data: savedReplay
         });
     } catch (error) { 
       next(error);

--- a/src/controllers/replay.controller.ts
+++ b/src/controllers/replay.controller.ts
@@ -4,6 +4,7 @@ import {
   ReplayFileRequest,
 } from '../types/replay.js';
 import { replayService } from '../services/replay.service.js';
+import { replaySaveFacade } from '../facade/replaySave.facade.js';
 
 /**
  * @route POST /api/replays
@@ -18,7 +19,7 @@ export const createReplay = async (
     const fileData = req.body; 
 
     try {
-        const savedReplay = await replayService.allSave(fileData);
+        const savedReplay = await replaySaveFacade.allSave(fileData);
         return res.status(201).json({
             status: 'success',
             message: 'Replay created successfully',

--- a/src/database/connectionPool.ts
+++ b/src/database/connectionPool.ts
@@ -104,3 +104,5 @@ export const testConnection = () => dbConnectionPool.testConnection();
 export const initializeDB = () => dbConnectionPool.initialize();
 export const closeDB = () => dbConnectionPool.close();
 export const isDBReady = () => dbConnectionPool.isReady();
+
+export type TransactionType = Parameters<Parameters<typeof db.transaction>[0]>[0];

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -64,3 +64,19 @@ export type Replay = typeof replay.$inferSelect;
 
 export type ErrorLog = typeof errorLog.$inferSelect;
 export type InsertErrorLog = typeof errorLog.$inferInsert;
+
+export const riotAccount = pgTable('riot_account', {
+  id: varchar('id', { length: 64 }).primaryKey().notNull(),
+  riotName: varchar('riot_name', { length: 128 }).notNull(),
+  riotNameTag: varchar('riot_name_tag', { length: 128 }).notNull(),
+  isMain: boolean('is_main').notNull().default(true),
+  createDate: timestamp('create_date').notNull().defaultNow(),
+  updateDate: timestamp('update_date')
+    .defaultNow()
+    .notNull()
+    .$onUpdate(() => new Date()),
+  isDeleted: boolean('is_deleted').notNull().default(false),
+});
+
+export type RiotAccount = typeof riotAccount.$inferInsert;
+export type InsertRiotAccount = typeof riotAccount.$inferInsert;

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -33,6 +33,7 @@ export const replay = pgTable('replay', {
   rawData: jsonb('raw_data').notNull(),
   hashData: varchar('hash_data', { length: 128 }).notNull(),
   gameType: char('game_type', { length: 1 }).notNull().default('1'),
+  season: varchar('season', { length: 32 }).notNull(),
   createUser: varchar('create_user', { length: 255 }).notNull(),
   guildId: varchar('guild_id', { length: 128 }).notNull().references(() => guild.id),
   createDate: timestamp('create_date').notNull().defaultNow(),

--- a/src/facade/replaySave.facade.ts
+++ b/src/facade/replaySave.facade.ts
@@ -22,7 +22,6 @@ export class ReplaySaveFacade {
         const guildResult = await guildService.upsertGuild(fileData.guild, tx);
         const savedReplay = await replayService.replaySave(fileData, rawDatas, tx);
         const riotAccountResult = await riotAccountService.upsertRiotAccount(rawDatas, tx);
-        console.log(riotAccountResult);
 
         return "";
       });

--- a/src/facade/replaySave.facade.ts
+++ b/src/facade/replaySave.facade.ts
@@ -1,0 +1,36 @@
+import { db, TransactionType  } from '../database/connectionPool.js';
+import { guildService } from'../services/guild.service.js';
+import { replayService } from '../services/replay.service.js';
+import { riotAccountService } from '../services/riotAccount.service.js';
+import { ReplayFileRequest } from '../types/replay.js';
+
+/**
+ * @desc 여러 저장 Service 로직 관리
+ */
+export class ReplaySaveFacade {
+
+  /**
+   * 리플레이 업로드 시작으로 replay, guild, riot_account, custom_match, match_participants, 
+   * guild_member 저장 로직 / 하나라도 실패시 전체 rollback
+   */
+  public async allSave (fileData: ReplayFileRequest) {
+    
+    try {
+      const result = await db.transaction(async (tx: TransactionType) => {
+        const rawDatas = await replayService.getRawDataes(fileData);
+        
+        const guildResult = await guildService.upsertGuild(fileData.guild, tx);
+        const savedReplay = await replayService.replaySave(fileData, rawDatas, tx);
+        const riotAccountResult = await riotAccountService.upsertRiotAccount(rawDatas, tx);
+        console.log(riotAccountResult);
+
+        return "";
+      });
+    } catch (err) {
+      throw err;
+    }
+
+  }
+}
+
+export const replaySaveFacade = new ReplaySaveFacade();

--- a/src/routes/replay.routes.ts
+++ b/src/routes/replay.routes.ts
@@ -28,10 +28,22 @@ const createReplaySchema = z.object({
       .string()
       .min(1, '생성 유저는 필수 입력 사항입니다.')
       .max(255, '생성 유저는 255자 이하여야 합니다.'),
-    guildId: z
-      .string()
-      .min(1, '길드 ID는 필수 입력 사항입니다.')
-      .max(128, '길드 ID는 128자 이하여야 합니다.'),
+    guild: z
+      .object(
+        {
+          id: z.string()
+          .min(1, 'guild Id is required')
+          .max(128, 'guild Id must be less than 128 characters'),
+          name: z.string()
+          .min(1, 'guild name is required')
+          .max(255, 'guild name must be less than 128 characters'),
+          languageCode: z.string()
+          .max(10, 'languageCode must be less than 10 characters')
+          .default('ko')
+        }
+      )
+      // .min(1, '길드 ID는 필수 입력 사항입니다.')
+      // .max(128, '길드 ID는 128자 이하여야 합니다.'),
   }),
 });
 

--- a/src/services/guild.service.ts
+++ b/src/services/guild.service.ts
@@ -1,6 +1,6 @@
 // src/services/guild.service.ts
 import { eq, ilike, desc, sql, and } from 'drizzle-orm';
-import { db } from '../database/connectionPool.js';
+import { db, TransactionType } from '../database/connectionPool.js';
 import { guild, InsertGuild } from '../database/schema.js';
 import { GetGuildsQuery, UpdateGuildRequest } from '../types/guild.js';
 
@@ -16,6 +16,23 @@ export class GuildService {
   public async insertGuild(newGuildData: InsertGuild) {
     const result = await db.insert(guild).values(newGuildData).returning();
     return result[0];
+  }
+
+  /**
+   * @desc 새로운 길드가 있으면 생성, 아니면 update
+   */
+  public async upsertGuild(newGuildData: InsertGuild, tx: TransactionType) {
+    const result = await tx.insert(guild).values(newGuildData)
+    .onConflictDoUpdate({
+      target: guild.id,
+      set: {
+        name: newGuildData.name,
+        languageCode: newGuildData.languageCode,
+      }
+    })
+    .returning();
+
+    return result;
   }
 
   /**

--- a/src/services/replay.service.ts
+++ b/src/services/replay.service.ts
@@ -8,6 +8,9 @@ import { BusinessError, SystemError } from '../types/error.js';
 
 import { guildService } from '../services/guild.service.js';
 
+// 시즌 
+const season = process.env.LOL_SEASON || 'error_season';
+
 /**
  * @desc 리플레이 파일 서비스
  */
@@ -163,6 +166,7 @@ export class ReplayService {
         rawData,
         hashData,
         gameType: gameType ?? '1',
+        season: season,
         createUser,
         guildId,
       })

--- a/src/services/replay.service.ts
+++ b/src/services/replay.service.ts
@@ -1,16 +1,35 @@
 import { eq, and, like, desc } from 'drizzle-orm';
-import { db } from '../database/connectionPool.js';
+import { db, TransactionType  } from '../database/connectionPool.js';
 import { replay } from '../database/schema.js';
 import { ReplayFileRequest } from '../types/replay.js';
 import { get } from 'https'; // http 또는 https 모듈
 import { createHash } from 'crypto';
 import { BusinessError, SystemError } from '../types/error.js';
 
+import { guildService } from '../services/guild.service.js';
+
 /**
  * @desc 리플레이 파일 서비스
  */
 export class ReplayService {
   constructor() {}
+
+  /**
+   * @desc 리플 업로드로 시작되는 모든 저장 로직 / 하나라도 실패시 전체 rollback
+   */
+  public async allSave (fileData: ReplayFileRequest) {
+    
+    try {
+      const result = await db.transaction(async (tx: TransactionType) => {
+        const guildResult = await guildService.upsertGuild(fileData.guild, tx);
+        const rawData = await this.replaySave(fileData, tx);
+        return "";
+      });
+    } catch (err) {
+      throw err;
+    }
+
+  }
 
   /**
    * @desc 주어진 데이터를 사용하여 SHA-256 해시를 생성
@@ -114,8 +133,9 @@ export class ReplayService {
    * @desc 리플레이 저장 및 처리
    * @param {ReplayFileRequest} fileData
    */
-  public async save(fileData: ReplayFileRequest) {
-    const { fileName, fileUrl, gameType, createUser, guildId } = fileData;
+  public async replaySave(fileData: ReplayFileRequest, tx: TransactionType) {
+    const { fileName, fileUrl, gameType, createUser } = fileData;
+    const guildId = fileData.guild.id;
 
     // 1. 리플레이 파일 데이터 가져오기
     const fileBuffer = await this.getInputStreamDiscordFile(fileUrl);
@@ -134,7 +154,7 @@ export class ReplayService {
 
     const replayCode = await this.generateReplayCode(fileName);
 
-    const newReplay = await db
+    const newReplay = await tx
       .insert(replay)
       .values({
         replayCode,

--- a/src/services/replay.service.ts
+++ b/src/services/replay.service.ts
@@ -66,22 +66,18 @@ export class ReplayService {
     const prefix = `RPY-${YYMMDD}-${fileName}-`;
 
     const lastReplay = await db
-      .select({ replayCode: replay.replayCode })
+      .select({ id: replay.id })
       .from(replay)
-      .where(like(replay.replayCode, `${prefix}%`))
-      .orderBy(desc(replay.replayCode))
+      .orderBy(desc(replay.id))
       .limit(1);
 
     let nextSequence = 1;
 
     if (lastReplay.length > 0) {
-      const lastCode = lastReplay[0].replayCode;
-      const parts = lastCode.split('-');
-      const lastSequenceStr = parts[parts.length - 1];
-      const lastSequence = parseInt(lastSequenceStr, 10);
+      const lastCode = lastReplay[0].id;
 
-      if (!isNaN(lastSequence)) {
-        nextSequence = lastSequence + 1;
+      if (!isNaN(lastCode)) {
+        nextSequence = lastCode + 1;
       }
     }
 

--- a/src/services/replay.service.ts
+++ b/src/services/replay.service.ts
@@ -1,12 +1,11 @@
 import { eq, and, like, desc } from 'drizzle-orm';
 import { db, TransactionType  } from '../database/connectionPool.js';
 import { replay } from '../database/schema.js';
-import { ReplayFileRequest } from '../types/replay.js';
+import { ReplayFileRequest, GetRawData } from '../types/replay.js';
 import { get } from 'https'; // http 또는 https 모듈
 import { createHash } from 'crypto';
 import { BusinessError, SystemError } from '../types/error.js';
 
-import { guildService } from '../services/guild.service.js';
 
 // 시즌 
 const season = process.env.LOL_SEASON || 'error_season';
@@ -16,23 +15,6 @@ const season = process.env.LOL_SEASON || 'error_season';
  */
 export class ReplayService {
   constructor() {}
-
-  /**
-   * @desc 리플 업로드로 시작되는 모든 저장 로직 / 하나라도 실패시 전체 rollback
-   */
-  public async allSave (fileData: ReplayFileRequest) {
-    
-    try {
-      const result = await db.transaction(async (tx: TransactionType) => {
-        const guildResult = await guildService.upsertGuild(fileData.guild, tx);
-        const rawData = await this.replaySave(fileData, tx);
-        return "";
-      });
-    } catch (err) {
-      throw err;
-    }
-
-  }
 
   /**
    * @desc 주어진 데이터를 사용하여 SHA-256 해시를 생성
@@ -133,24 +115,33 @@ export class ReplayService {
   }
 
   /**
-   * @desc 리플레이 저장 및 처리
-   * @param {ReplayFileRequest} fileData
+   * @desc get rawdataes
    */
-  public async replaySave(fileData: ReplayFileRequest, tx: TransactionType) {
-    const { fileName, fileUrl, gameType, createUser } = fileData;
-    const guildId = fileData.guild.id;
+  public async getRawDataes(fileData: ReplayFileRequest): Promise<GetRawData[]> {
+    const { fileUrl } = fileData;
 
     // 1. 리플레이 파일 데이터 가져오기
     const fileBuffer = await this.getInputStreamDiscordFile(fileUrl);
 
     // 2. 파일 파싱
     const rawDataString = await this.parseReplayData(fileBuffer);
-    const rawData = JSON.parse(rawDataString);
+    const rawDataes = JSON.parse(rawDataString);
 
-    // 3. 해시 생성
+    return rawDataes;
+  }
+
+  /**
+   * @desc 리플레이 저장
+   * @param {ReplayFileRequest} fileData
+   */
+  public async replaySave(fileData: ReplayFileRequest, rawData: GetRawData[], tx: TransactionType) {
+    const { fileName, fileUrl, gameType, createUser } = fileData;
+    const guildId = fileData.guild.id;
+
+    const rawDataString = JSON.stringify(rawData);
     const hashData = this.generateHash(rawDataString);
 
-    // 4. 중복된 데이터 확인
+    // 1. 중복된 데이터 확인
     if (await this.checkDuplicateByHash(hashData, guildId)) {
       throw new BusinessError("duplicated replay data", 400, {"isLoggable": false});
     }

--- a/src/services/riotAccount.service.ts
+++ b/src/services/riotAccount.service.ts
@@ -1,0 +1,61 @@
+import { eq, and, like, desc, sql } from 'drizzle-orm';
+import { db, TransactionType  } from '../database/connectionPool.js';
+import { riotAccount, InsertRiotAccount } from '../database/schema.js';
+
+export interface riotAccountData {
+  PUUID: string;
+  RIOT_ID_GAME_NAME: string;
+  RIOT_ID_TAG_LINE: string;
+};
+
+/**
+ * @desc Riot 계정 서비스
+ */
+export class RiotAccountService {
+  constructor() {}
+
+  /**
+   * @desc 라이엇계정 기존 puuid 가 있으면 update // 없으면 insert
+   * 트랜잭션
+   */
+  public async upsertRiotAccount(rawDatas: riotAccountData[], tx: TransactionType) {
+    const RiotAccountData = await this.parsedRawData(rawDatas);
+
+    const result = await tx
+    .insert(riotAccount)
+    .values(RiotAccountData)
+    .onConflictDoUpdate({
+      target: riotAccount.id,
+      set: {
+        riotName: riotAccount.riotName,
+        riotNameTag: riotAccount.riotNameTag,
+        updateDate: new Date(),
+      }
+    })
+    .returning();
+
+    return result;
+  }
+
+  /**
+   * @desc rawdataes 에서 riotaccount 추출
+   */
+  public async parsedRawData(rawDataes: riotAccountData[]): Promise<InsertRiotAccount[]> {
+    const parsedRiotAccounts: InsertRiotAccount[] = [];
+
+    for(const rawData of rawDataes) {
+      const puuid = rawData.PUUID;
+      const riotName = rawData.RIOT_ID_GAME_NAME;
+      const riotNameTag = rawData.RIOT_ID_TAG_LINE;
+
+      parsedRiotAccounts.push({
+        id: puuid,
+        riotName: riotName,
+        riotNameTag: riotNameTag
+      });
+    }
+    return parsedRiotAccounts;
+  }
+}
+
+export const riotAccountService = new RiotAccountService();

--- a/src/types/replay.ts
+++ b/src/types/replay.ts
@@ -22,4 +22,49 @@ export interface GetReplaysQuery {
   gameType?: string;
 }
 
+export interface GetRawData {
+  EXP: string;
+  SKIN: string;
+  TEAM: string;
+  ITEM0: string;
+  ITEM1: string;
+  ITEM2: string;
+  ITEM3: string;
+  ITEM4: string;
+  ITEM5: string;
+  ITEM6: string;
+  LEVEL: string;
+  PERK0?: string;
+  PERK1?: string;
+  PERK2?: string;
+  PERK3?: string;
+  PERK4?: string;
+  PERK5?: string;
+  PUUID: string;
+  ASSISTS: string;
+  NUM_DEATHS: string;
+  GOLD_EARNED: string;
+  KEYSTONE_ID: string;
+  PENTA_KILLS: string;
+  TIME_PLAYED: string;
+  VISION_SCORE: string;
+  VISION_BOUGHT: string;
+  TEAM_POSITION: string;
+  MINIONS_KILLED: string;
+  PERK_SUB_STYLE: string;
+  CHAMPIONS_KILLED: string;
+  RIOT_ID_TAG_LINE: string;
+  RIOT_ID_GAME_NAME: string;
+  SUMMONER_SPELL_1?: string;
+  SUMMONER_SPELL_2?: string;
+  TIME_CCING_OTHERS: string;
+  TOTAL_DAMAGE_DEALT_TO_CHAMPIONS: string;
+  TOTAL_DAMAGE_DEALT_TO_BUILDINGS: string;
+  TOTAL_DAMAGE_TAKEN: string;
+  INDIVIDUAL_POSITION: string;
+  NEUTRAL_MINIONS_KILLED: string;
+  NEUTRAL_MINIONS_KILLED_YOUR_JUNGLE: string;
+  NEUTRAL_MINIONS_KILLED_ENEMY_JUNGLE: string;
+}
+
 export type { Replay };

--- a/src/types/replay.ts
+++ b/src/types/replay.ts
@@ -1,11 +1,11 @@
-import { Replay } from '../database/schema.js';
+import { Guild, Replay } from '../database/schema.js';
 
 export interface ReplayFileRequest {
   fileName: string;
   fileUrl: string;
   gameType?: string;
   createUser: string;
-  guildId: string;
+  guild: Guild;
 }
 
 export interface ReplayResponse {

--- a/src/types/riotAccount.ts
+++ b/src/types/riotAccount.ts
@@ -1,0 +1,16 @@
+import { RiotAccount } from "../database/schema";
+
+export interface RiotAccountResponse {
+  status: 'success' | 'error';
+  messsage: string;
+  data?: RiotAccount | RiotAccount[] | null;
+}
+
+export interface GetRiotAccountsQuery {
+  page?: number;
+  limit?: number;
+  search?: string;
+  
+}
+
+export type { RiotAccount };


### PR DESCRIPTION
## replayCode 생성 로직 변경
- replayCode 생성 로직에서 잘못된 where 조건문 삭제

## Replay 저장 -> Guild 저장
- 리플레이 등록 후 replay 저장과 guild 저장까지
- guild 저장 시 기존 id 존재에 따라 upsert 

## season 컬럼 추가
- replay 테이블 season 컬럼 추가 
- 역할: 2024 시즌, 2025 시즌 나누기, 그 이후 시즌 나누기 용도
- custom_match에도 추가 예정
- .env.development LOL_SEASON 값 추가

## riotAccount 모듈, 저장 api 추가
- 리플레이 등록 후 replay 저장, guild 저장, riot_account 저장
- riot_account 저장 시 기존 id 존재에 따라 upsert

## replaySave facade 패턴 적용
- replaySave 전체 저장 로직을 facade 패턴으로 분리

## 앞으로 할 일 
- custom_match 저장
- match_participants 저장
- guild_member 저장

[gmok 테이블 정의서](https://docs.google.com/spreadsheets/d/1oD5gFGNEUXrPCuNzZ6i1nxeybfkgqfcbCsfX_ZfXSG8/edit?gid=1781982796#gid=1781982796)

