### PR TITLE
TRC-127V2 리플 저장 로직 1차 검토

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -16,3 +16,6 @@ COOKIE_SECRET=cookieSecret
 # SSL Configuration (development)
 DB_SSL=true
 DB_SSL_REJECT_UNAUTHORIZED=false
+
+# LoL season
+LOL_SEASON=2025

--- a/src/controllers/replay.controller.ts
+++ b/src/controllers/replay.controller.ts
@@ -18,11 +18,11 @@ export const createReplay = async (
     const fileData = req.body; 
 
     try {
-        const savedReplay = await replayService.save(fileData);
+        const savedReplay = await replayService.allSave(fileData);
         return res.status(201).json({
             status: 'success',
             message: 'Replay created successfully',
-            data: savedReplay
+            // data: savedReplay
         });
     } catch (error) { 
       next(error);

--- a/src/controllers/replay.controller.ts
+++ b/src/controllers/replay.controller.ts
@@ -23,7 +23,7 @@ export const createReplay = async (
         return res.status(201).json({
             status: 'success',
             message: 'Replay created successfully',
-            // data: savedReplay
+            data: savedReplay
         });
     } catch (error) { 
       next(error);

--- a/src/controllers/replay.controller.ts
+++ b/src/controllers/replay.controller.ts
@@ -4,6 +4,7 @@ import {
   ReplayFileRequest,
 } from '../types/replay.js';
 import { replayService } from '../services/replay.service.js';
+import { replaySaveFacade } from '../facade/replaySave.facade.js';
 
 /**
  * @route POST /api/replays
@@ -18,7 +19,7 @@ export const createReplay = async (
     const fileData = req.body; 
 
     try {
-        const savedReplay = await replayService.allSave(fileData);
+        const savedReplay = await replaySaveFacade.allSave(fileData);
         return res.status(201).json({
             status: 'success',
             message: 'Replay created successfully',

--- a/src/database/connectionPool.ts
+++ b/src/database/connectionPool.ts
@@ -104,3 +104,5 @@ export const testConnection = () => dbConnectionPool.testConnection();
 export const initializeDB = () => dbConnectionPool.initialize();
 export const closeDB = () => dbConnectionPool.close();
 export const isDBReady = () => dbConnectionPool.isReady();
+
+export type TransactionType = Parameters<Parameters<typeof db.transaction>[0]>[0];

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -1,4 +1,5 @@
 import { pgTable, text, varchar, jsonb, char, timestamp, boolean, integer } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 
 export const guild = pgTable('guild', {
   id: varchar('id', { length: 128 }).primaryKey(),
@@ -66,7 +67,11 @@ export type ErrorLog = typeof errorLog.$inferSelect;
 export type InsertErrorLog = typeof errorLog.$inferInsert;
 
 export const riotAccount = pgTable('riot_account', {
-  id: varchar('id', { length: 64 }).primaryKey().notNull(),
+  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+  puuid: varchar('puuid', { length: 128 }).notNull().unique(),
+  playerCode: varchar('player_code', {length: 64 })
+  .generatedAlwaysAs(sql`'PLR_' || lpad(id::text, 6, '0')`, )
+  .notNull().unique(),
   riotName: varchar('riot_name', { length: 128 }).notNull(),
   riotNameTag: varchar('riot_name_tag', { length: 128 }).notNull(),
   isMain: boolean('is_main').notNull().default(true),

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -64,3 +64,19 @@ export type Replay = typeof replay.$inferSelect;
 
 export type ErrorLog = typeof errorLog.$inferSelect;
 export type InsertErrorLog = typeof errorLog.$inferInsert;
+
+export const riotAccount = pgTable('riot_account', {
+  id: varchar('id', { length: 64 }).primaryKey().notNull(),
+  riotName: varchar('riot_name', { length: 128 }).notNull(),
+  riotNameTag: varchar('riot_name_tag', { length: 128 }).notNull(),
+  isMain: boolean('is_main').notNull().default(true),
+  createDate: timestamp('create_date').notNull().defaultNow(),
+  updateDate: timestamp('update_date')
+    .defaultNow()
+    .notNull()
+    .$onUpdate(() => new Date()),
+  isDeleted: boolean('is_deleted').notNull().default(false),
+});
+
+export type RiotAccount = typeof riotAccount.$inferInsert;
+export type InsertRiotAccount = typeof riotAccount.$inferInsert;

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -33,6 +33,7 @@ export const replay = pgTable('replay', {
   rawData: jsonb('raw_data').notNull(),
   hashData: varchar('hash_data', { length: 128 }).notNull(),
   gameType: char('game_type', { length: 1 }).notNull().default('1'),
+  season: varchar('season', { length: 32 }).notNull(),
   createUser: varchar('create_user', { length: 255 }).notNull(),
   guildId: varchar('guild_id', { length: 128 }).notNull().references(() => guild.id),
   createDate: timestamp('create_date').notNull().defaultNow(),

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -78,5 +78,5 @@ export const riotAccount = pgTable('riot_account', {
   isDeleted: boolean('is_deleted').notNull().default(false),
 });
 
-export type RiotAccount = typeof riotAccount.$inferInsert;
+export type RiotAccount = typeof riotAccount.$inferSelect;
 export type InsertRiotAccount = typeof riotAccount.$inferInsert;

--- a/src/facade/replaySave.facade.ts
+++ b/src/facade/replaySave.facade.ts
@@ -16,11 +16,11 @@ export class ReplaySaveFacade {
   public async allSave (fileData: ReplayFileRequest): Promise<Replay> {
     try {
       return await db.transaction(async (tx: TransactionType) => {
-        const rawDatas = await replayService.getRawDataes(fileData);
+        const rawData = await replayService.getRawData(fileData);
         
         await guildService.upsertGuild(fileData.guild, tx);
-        const savedReplay = await replayService.replaySave(fileData, rawDatas, tx);
-        await riotAccountService.upsertRiotAccount(rawDatas, tx);
+        const savedReplay = await replayService.replaySave(fileData, rawData, tx);
+        await riotAccountService.upsertRiotAccount(rawData, tx);
 
         return savedReplay;
       });

--- a/src/facade/replaySave.facade.ts
+++ b/src/facade/replaySave.facade.ts
@@ -2,7 +2,7 @@ import { db, TransactionType  } from '../database/connectionPool.js';
 import { guildService } from'../services/guild.service.js';
 import { replayService } from '../services/replay.service.js';
 import { riotAccountService } from '../services/riotAccount.service.js';
-import { ReplayFileRequest } from '../types/replay.js';
+import { Replay, ReplayFileRequest } from '../types/replay.js';
 
 /**
  * @desc 여러 저장 Service 로직 관리
@@ -13,17 +13,16 @@ export class ReplaySaveFacade {
    * 리플레이 업로드 시작으로 replay, guild, riot_account, custom_match, match_participants, 
    * guild_member 저장 로직 / 하나라도 실패시 전체 rollback
    */
-  public async allSave (fileData: ReplayFileRequest) {
-    
+  public async allSave (fileData: ReplayFileRequest): Promise<Replay> {
     try {
-      const result = await db.transaction(async (tx: TransactionType) => {
+      return await db.transaction(async (tx: TransactionType) => {
         const rawDatas = await replayService.getRawDataes(fileData);
         
-        const guildResult = await guildService.upsertGuild(fileData.guild, tx);
+        await guildService.upsertGuild(fileData.guild, tx);
         const savedReplay = await replayService.replaySave(fileData, rawDatas, tx);
-        const riotAccountResult = await riotAccountService.upsertRiotAccount(rawDatas, tx);
+        await riotAccountService.upsertRiotAccount(rawDatas, tx);
 
-        return "";
+        return savedReplay;
       });
     } catch (err) {
       throw err;

--- a/src/facade/replaySave.facade.ts
+++ b/src/facade/replaySave.facade.ts
@@ -22,7 +22,6 @@ export class ReplaySaveFacade {
         const guildResult = await guildService.upsertGuild(fileData.guild, tx);
         const savedReplay = await replayService.replaySave(fileData, rawDatas, tx);
         const riotAccountResult = await riotAccountService.upsertRiotAccount(rawDatas, tx);
-        console.log(riotAccountResult);
 
         return "";
       });

--- a/src/facade/replaySave.facade.ts
+++ b/src/facade/replaySave.facade.ts
@@ -1,0 +1,36 @@
+import { db, TransactionType  } from '../database/connectionPool.js';
+import { guildService } from'../services/guild.service.js';
+import { replayService } from '../services/replay.service.js';
+import { riotAccountService } from '../services/riotAccount.service.js';
+import { ReplayFileRequest } from '../types/replay.js';
+
+/**
+ * @desc 여러 저장 Service 로직 관리
+ */
+export class ReplaySaveFacade {
+
+  /**
+   * 리플레이 업로드 시작으로 replay, guild, riot_account, custom_match, match_participants, 
+   * guild_member 저장 로직 / 하나라도 실패시 전체 rollback
+   */
+  public async allSave (fileData: ReplayFileRequest) {
+    
+    try {
+      const result = await db.transaction(async (tx: TransactionType) => {
+        const rawDatas = await replayService.getRawDataes(fileData);
+        
+        const guildResult = await guildService.upsertGuild(fileData.guild, tx);
+        const savedReplay = await replayService.replaySave(fileData, rawDatas, tx);
+        const riotAccountResult = await riotAccountService.upsertRiotAccount(rawDatas, tx);
+        console.log(riotAccountResult);
+
+        return "";
+      });
+    } catch (err) {
+      throw err;
+    }
+
+  }
+}
+
+export const replaySaveFacade = new ReplaySaveFacade();

--- a/src/routes/replay.routes.ts
+++ b/src/routes/replay.routes.ts
@@ -42,8 +42,6 @@ const createReplaySchema = z.object({
           .default('ko')
         }
       )
-      // .min(1, '길드 ID는 필수 입력 사항입니다.')
-      // .max(128, '길드 ID는 128자 이하여야 합니다.'),
   }),
 });
 
@@ -51,7 +49,7 @@ const deleteReplaySchema = z.object({
   params: z.object({
     replayCode: z
       .string()
-      .min(1, 'Replay code is required') // 리플레이 코드는 필수 입력 사항입니다.
+      .min(1, 'Replay code is required')
       .max(255, 'Replay code must be less than 255 characters'),
   }),
 });

--- a/src/routes/replay.routes.ts
+++ b/src/routes/replay.routes.ts
@@ -28,10 +28,22 @@ const createReplaySchema = z.object({
       .string()
       .min(1, '생성 유저는 필수 입력 사항입니다.')
       .max(255, '생성 유저는 255자 이하여야 합니다.'),
-    guildId: z
-      .string()
-      .min(1, '길드 ID는 필수 입력 사항입니다.')
-      .max(128, '길드 ID는 128자 이하여야 합니다.'),
+    guild: z
+      .object(
+        {
+          id: z.string()
+          .min(1, 'guild Id is required')
+          .max(128, 'guild Id must be less than 128 characters'),
+          name: z.string()
+          .min(1, 'guild name is required')
+          .max(255, 'guild name must be less than 128 characters'),
+          languageCode: z.string()
+          .max(10, 'languageCode must be less than 10 characters')
+          .default('ko')
+        }
+      )
+      // .min(1, '길드 ID는 필수 입력 사항입니다.')
+      // .max(128, '길드 ID는 128자 이하여야 합니다.'),
   }),
 });
 

--- a/src/services/guild.service.ts
+++ b/src/services/guild.service.ts
@@ -1,6 +1,6 @@
 // src/services/guild.service.ts
 import { eq, ilike, desc, sql, and } from 'drizzle-orm';
-import { db } from '../database/connectionPool.js';
+import { db, TransactionType } from '../database/connectionPool.js';
 import { guild, InsertGuild } from '../database/schema.js';
 import { GetGuildsQuery, UpdateGuildRequest } from '../types/guild.js';
 
@@ -16,6 +16,23 @@ export class GuildService {
   public async insertGuild(newGuildData: InsertGuild) {
     const result = await db.insert(guild).values(newGuildData).returning();
     return result[0];
+  }
+
+  /**
+   * @desc 새로운 길드가 있으면 생성, 아니면 update
+   */
+  public async upsertGuild(newGuildData: InsertGuild, tx: TransactionType) {
+    const result = await tx.insert(guild).values(newGuildData)
+    .onConflictDoUpdate({
+      target: guild.id,
+      set: {
+        name: newGuildData.name,
+        languageCode: newGuildData.languageCode,
+      }
+    })
+    .returning();
+
+    return result;
   }
 
   /**

--- a/src/services/guild.service.ts
+++ b/src/services/guild.service.ts
@@ -3,6 +3,7 @@ import { eq, ilike, desc, sql, and } from 'drizzle-orm';
 import { db, TransactionType } from '../database/connectionPool.js';
 import { guild, InsertGuild } from '../database/schema.js';
 import { GetGuildsQuery, UpdateGuildRequest } from '../types/guild.js';
+import { BusinessError, SystemError } from '../types/error.js';
 
 /**
  * @desc 길드 데이터의 생성, 조회, 수정, 삭제를 담당하는 서비스 클래스
@@ -22,17 +23,23 @@ export class GuildService {
    * @desc 새로운 길드가 있으면 생성, 아니면 update
    */
   public async upsertGuild(newGuildData: InsertGuild, tx: TransactionType) {
-    const result = await tx.insert(guild).values(newGuildData)
-    .onConflictDoUpdate({
-      target: guild.id,
-      set: {
-        name: newGuildData.name,
-        languageCode: newGuildData.languageCode,
-      }
-    })
-    .returning();
-
-    return result;
+    try {
+      const result = await tx
+        .insert(guild)
+        .values(newGuildData)
+        .onConflictDoUpdate({
+          target: guild.id,
+          set: {
+            name: newGuildData.name,
+            languageCode: newGuildData.languageCode,
+          },
+        })
+        .returning();
+      return result;
+    } catch (error) {
+      console.error('Error upserting Guild',error);
+      throw new SystemError('Guild error while upserting', 500);
+    }
   }
 
   /**

--- a/src/services/guild.service.ts
+++ b/src/services/guild.service.ts
@@ -32,7 +32,9 @@ export class GuildService {
           set: {
             name: newGuildData.name,
             languageCode: newGuildData.languageCode,
+            updateDate: new Date(),
           },
+          where: sql`${guild.name} IS DISTINCT FROM ${newGuildData.name} `
         })
         .returning();
       return result;

--- a/src/services/replay.service.ts
+++ b/src/services/replay.service.ts
@@ -8,6 +8,9 @@ import { BusinessError, SystemError } from '../types/error.js';
 
 import { guildService } from '../services/guild.service.js';
 
+// 시즌 
+const season = process.env.LOL_SEASON || 'error_season';
+
 /**
  * @desc 리플레이 파일 서비스
  */
@@ -163,6 +166,7 @@ export class ReplayService {
         rawData,
         hashData,
         gameType: gameType ?? '1',
+        season: season,
         createUser,
         guildId,
       })

--- a/src/services/replay.service.ts
+++ b/src/services/replay.service.ts
@@ -1,16 +1,35 @@
 import { eq, and, like, desc } from 'drizzle-orm';
-import { db } from '../database/connectionPool.js';
+import { db, TransactionType  } from '../database/connectionPool.js';
 import { replay } from '../database/schema.js';
 import { ReplayFileRequest } from '../types/replay.js';
 import { get } from 'https'; // http 또는 https 모듈
 import { createHash } from 'crypto';
 import { BusinessError, SystemError } from '../types/error.js';
 
+import { guildService } from '../services/guild.service.js';
+
 /**
  * @desc 리플레이 파일 서비스
  */
 export class ReplayService {
   constructor() {}
+
+  /**
+   * @desc 리플 업로드로 시작되는 모든 저장 로직 / 하나라도 실패시 전체 rollback
+   */
+  public async allSave (fileData: ReplayFileRequest) {
+    
+    try {
+      const result = await db.transaction(async (tx: TransactionType) => {
+        const guildResult = await guildService.upsertGuild(fileData.guild, tx);
+        const rawData = await this.replaySave(fileData, tx);
+        return "";
+      });
+    } catch (err) {
+      throw err;
+    }
+
+  }
 
   /**
    * @desc 주어진 데이터를 사용하여 SHA-256 해시를 생성
@@ -114,8 +133,9 @@ export class ReplayService {
    * @desc 리플레이 저장 및 처리
    * @param {ReplayFileRequest} fileData
    */
-  public async save(fileData: ReplayFileRequest) {
-    const { fileName, fileUrl, gameType, createUser, guildId } = fileData;
+  public async replaySave(fileData: ReplayFileRequest, tx: TransactionType) {
+    const { fileName, fileUrl, gameType, createUser } = fileData;
+    const guildId = fileData.guild.id;
 
     // 1. 리플레이 파일 데이터 가져오기
     const fileBuffer = await this.getInputStreamDiscordFile(fileUrl);
@@ -134,7 +154,7 @@ export class ReplayService {
 
     const replayCode = await this.generateReplayCode(fileName);
 
-    const newReplay = await db
+    const newReplay = await tx
       .insert(replay)
       .values({
         replayCode,

--- a/src/services/replay.service.ts
+++ b/src/services/replay.service.ts
@@ -55,6 +55,7 @@ export class ReplayService {
           resolve(buffer);
         });
       }).on('error', (err) => {
+        console.error('Error getInputStreaming replay file', err);
         throw new SystemError("replay error while getInputStreaming file");
       });
     });
@@ -110,6 +111,7 @@ export class ReplayService {
 
       return JSON.stringify(statsArray);
     } catch (error) {
+      console.error('Error parsing replay data', error);
       throw new SystemError("replay error while parsing data");
     }
   }

--- a/src/services/replay.service.ts
+++ b/src/services/replay.service.ts
@@ -66,22 +66,18 @@ export class ReplayService {
     const prefix = `RPY-${YYMMDD}-${fileName}-`;
 
     const lastReplay = await db
-      .select({ replayCode: replay.replayCode })
+      .select({ id: replay.id })
       .from(replay)
-      .where(like(replay.replayCode, `${prefix}%`))
-      .orderBy(desc(replay.replayCode))
+      .orderBy(desc(replay.id))
       .limit(1);
 
     let nextSequence = 1;
 
     if (lastReplay.length > 0) {
-      const lastCode = lastReplay[0].replayCode;
-      const parts = lastCode.split('-');
-      const lastSequenceStr = parts[parts.length - 1];
-      const lastSequence = parseInt(lastSequenceStr, 10);
+      const lastCode = lastReplay[0].id;
 
-      if (!isNaN(lastSequence)) {
-        nextSequence = lastSequence + 1;
+      if (!isNaN(lastCode)) {
+        nextSequence = lastCode + 1;
       }
     }
 

--- a/src/services/replay.service.ts
+++ b/src/services/replay.service.ts
@@ -1,12 +1,11 @@
 import { eq, and, like, desc } from 'drizzle-orm';
 import { db, TransactionType  } from '../database/connectionPool.js';
 import { replay } from '../database/schema.js';
-import { ReplayFileRequest } from '../types/replay.js';
+import { ReplayFileRequest, GetRawData } from '../types/replay.js';
 import { get } from 'https'; // http 또는 https 모듈
 import { createHash } from 'crypto';
 import { BusinessError, SystemError } from '../types/error.js';
 
-import { guildService } from '../services/guild.service.js';
 
 // 시즌 
 const season = process.env.LOL_SEASON || 'error_season';
@@ -16,23 +15,6 @@ const season = process.env.LOL_SEASON || 'error_season';
  */
 export class ReplayService {
   constructor() {}
-
-  /**
-   * @desc 리플 업로드로 시작되는 모든 저장 로직 / 하나라도 실패시 전체 rollback
-   */
-  public async allSave (fileData: ReplayFileRequest) {
-    
-    try {
-      const result = await db.transaction(async (tx: TransactionType) => {
-        const guildResult = await guildService.upsertGuild(fileData.guild, tx);
-        const rawData = await this.replaySave(fileData, tx);
-        return "";
-      });
-    } catch (err) {
-      throw err;
-    }
-
-  }
 
   /**
    * @desc 주어진 데이터를 사용하여 SHA-256 해시를 생성
@@ -133,24 +115,33 @@ export class ReplayService {
   }
 
   /**
-   * @desc 리플레이 저장 및 처리
-   * @param {ReplayFileRequest} fileData
+   * @desc get rawdataes
    */
-  public async replaySave(fileData: ReplayFileRequest, tx: TransactionType) {
-    const { fileName, fileUrl, gameType, createUser } = fileData;
-    const guildId = fileData.guild.id;
+  public async getRawDataes(fileData: ReplayFileRequest): Promise<GetRawData[]> {
+    const { fileUrl } = fileData;
 
     // 1. 리플레이 파일 데이터 가져오기
     const fileBuffer = await this.getInputStreamDiscordFile(fileUrl);
 
     // 2. 파일 파싱
     const rawDataString = await this.parseReplayData(fileBuffer);
-    const rawData = JSON.parse(rawDataString);
+    const rawDataes = JSON.parse(rawDataString);
 
-    // 3. 해시 생성
+    return rawDataes;
+  }
+
+  /**
+   * @desc 리플레이 저장
+   * @param {ReplayFileRequest} fileData
+   */
+  public async replaySave(fileData: ReplayFileRequest, rawData: GetRawData[], tx: TransactionType) {
+    const { fileName, fileUrl, gameType, createUser } = fileData;
+    const guildId = fileData.guild.id;
+
+    const rawDataString = JSON.stringify(rawData);
     const hashData = this.generateHash(rawDataString);
 
-    // 4. 중복된 데이터 확인
+    // 1. 중복된 데이터 확인
     if (await this.checkDuplicateByHash(hashData, guildId)) {
       throw new BusinessError("duplicated replay data", 400, {"isLoggable": false});
     }

--- a/src/services/replay.service.ts
+++ b/src/services/replay.service.ts
@@ -1,11 +1,10 @@
 import { eq, and, like, desc } from 'drizzle-orm';
 import { db, TransactionType  } from '../database/connectionPool.js';
 import { replay } from '../database/schema.js';
-import { ReplayFileRequest, GetRawData } from '../types/replay.js';
+import { ReplayFileRequest } from '../types/replay.js';
 import { get } from 'https'; // http 또는 https 모듈
 import { createHash } from 'crypto';
 import { BusinessError, SystemError } from '../types/error.js';
-
 
 // 시즌 
 const season = process.env.LOL_SEASON || 'error_season';
@@ -119,7 +118,7 @@ export class ReplayService {
   /**
    * @desc get rawdataes
    */
-  public async getRawDataes(fileData: ReplayFileRequest): Promise<GetRawData[]> {
+  public async getRawData(fileData: ReplayFileRequest) {
     const { fileUrl } = fileData;
 
     // 1. 리플레이 파일 데이터 가져오기
@@ -136,7 +135,7 @@ export class ReplayService {
    * @desc 리플레이 저장
    * @param {ReplayFileRequest} fileData
    */
-  public async replaySave(fileData: ReplayFileRequest, rawData: GetRawData[], tx: TransactionType) {
+  public async replaySave(fileData: ReplayFileRequest, rawData: any, tx: TransactionType) {
     const { fileName, fileUrl, gameType, createUser } = fileData;
     const guildId = fileData.guild.id;
 

--- a/src/services/riotAccount.service.ts
+++ b/src/services/riotAccount.service.ts
@@ -1,6 +1,7 @@
 import { eq, and, like, desc, sql } from 'drizzle-orm';
 import { db, TransactionType  } from '../database/connectionPool.js';
 import { riotAccount, InsertRiotAccount } from '../database/schema.js';
+import { BusinessError, SystemError } from '../types/error.js';
 
 export interface riotAccountData {
   PUUID: string;
@@ -21,26 +22,31 @@ export class RiotAccountService {
   public async upsertRiotAccount(rawDatas: riotAccountData[], tx: TransactionType) {
     const RiotAccountData = await this.parsedRawData(rawDatas);
 
-    const result = await tx
-    .insert(riotAccount)
-    .values(RiotAccountData)
-    .onConflictDoUpdate({
-      target: riotAccount.id,
-      set: {
-        riotName: riotAccount.riotName,
-        riotNameTag: riotAccount.riotNameTag,
-        updateDate: new Date(),
-      }
-    })
-    .returning();
+    try {
+      const result = await tx
+        .insert(riotAccount)
+        .values(RiotAccountData)
+        .onConflictDoUpdate({
+          target: riotAccount.id,
+          set: {
+            riotName: riotAccount.riotName,
+            riotNameTag: riotAccount.riotNameTag,
+            updateDate: new Date(),
+          },
+        })
+        .returning();
 
-    return result;
+      return result;
+    } catch (error) {
+      console.error('Error upserting RiotAccount', error);
+      throw new SystemError('RiotAccount error while upserting', 500);
+    }
   }
 
   /**
    * @desc rawdataes 에서 riotaccount 추출
    */
-  public async parsedRawData(rawDataes: riotAccountData[]): Promise<InsertRiotAccount[]> {
+  private async parsedRawData(rawDataes: riotAccountData[]): Promise<InsertRiotAccount[]> {
     const parsedRiotAccounts: InsertRiotAccount[] = [];
 
     for(const rawData of rawDataes) {

--- a/src/services/riotAccount.service.ts
+++ b/src/services/riotAccount.service.ts
@@ -1,0 +1,61 @@
+import { eq, and, like, desc, sql } from 'drizzle-orm';
+import { db, TransactionType  } from '../database/connectionPool.js';
+import { riotAccount, InsertRiotAccount } from '../database/schema.js';
+
+export interface riotAccountData {
+  PUUID: string;
+  RIOT_ID_GAME_NAME: string;
+  RIOT_ID_TAG_LINE: string;
+};
+
+/**
+ * @desc Riot 계정 서비스
+ */
+export class RiotAccountService {
+  constructor() {}
+
+  /**
+   * @desc 라이엇계정 기존 puuid 가 있으면 update // 없으면 insert
+   * 트랜잭션
+   */
+  public async upsertRiotAccount(rawDatas: riotAccountData[], tx: TransactionType) {
+    const RiotAccountData = await this.parsedRawData(rawDatas);
+
+    const result = await tx
+    .insert(riotAccount)
+    .values(RiotAccountData)
+    .onConflictDoUpdate({
+      target: riotAccount.id,
+      set: {
+        riotName: riotAccount.riotName,
+        riotNameTag: riotAccount.riotNameTag,
+        updateDate: new Date(),
+      }
+    })
+    .returning();
+
+    return result;
+  }
+
+  /**
+   * @desc rawdataes 에서 riotaccount 추출
+   */
+  public async parsedRawData(rawDataes: riotAccountData[]): Promise<InsertRiotAccount[]> {
+    const parsedRiotAccounts: InsertRiotAccount[] = [];
+
+    for(const rawData of rawDataes) {
+      const puuid = rawData.PUUID;
+      const riotName = rawData.RIOT_ID_GAME_NAME;
+      const riotNameTag = rawData.RIOT_ID_TAG_LINE;
+
+      parsedRiotAccounts.push({
+        id: puuid,
+        riotName: riotName,
+        riotNameTag: riotNameTag
+      });
+    }
+    return parsedRiotAccounts;
+  }
+}
+
+export const riotAccountService = new RiotAccountService();

--- a/src/services/riotAccount.service.ts
+++ b/src/services/riotAccount.service.ts
@@ -1,13 +1,16 @@
-import { eq, and, like, desc, sql } from 'drizzle-orm';
-import { db, TransactionType  } from '../database/connectionPool.js';
+import { z } from 'zod';
+import { eq, and, like, desc, sql, is } from 'drizzle-orm';
+import { db, TransactionType } from '../database/connectionPool.js';
 import { riotAccount, InsertRiotAccount } from '../database/schema.js';
 import { BusinessError, SystemError } from '../types/error.js';
 
-export interface riotAccountData {
-  PUUID: string;
-  RIOT_ID_GAME_NAME: string;
-  RIOT_ID_TAG_LINE: string;
-};
+const RiotAccountDataSchema = z.object({
+  PUUID: z.string().min(1, 'PUUID는 필수 항목입니다.'),
+  RIOT_ID_GAME_NAME: z.string().min(1, 'RIOT_ID_GAME_NAME은 필수 항목입니다.'),
+  RIOT_ID_TAG_LINE: z.string().min(1, 'RIOT_ID_TAG_LINE은 필수 항목입니다.'),
+});
+
+const RiotAccountDataArraySchema = z.array(RiotAccountDataSchema);
 
 /**
  * @desc Riot 계정 서비스
@@ -19,13 +22,13 @@ export class RiotAccountService {
    * @desc 라이엇계정 기존 puuid 가 있으면 update // 없으면 insert
    * 트랜잭션
    */
-  public async upsertRiotAccount(rawDatas: riotAccountData[], tx: TransactionType) {
-    const RiotAccountData = await this.parsedRawData(rawDatas);
-
+  public async upsertRiotAccount(rawData: any[], tx: TransactionType) {
     try {
+      const riotAccountData = this.parsedRawData(rawData);
+
       const result = await tx
         .insert(riotAccount)
-        .values(RiotAccountData)
+        .values(riotAccountData)
         .onConflictDoUpdate({
           target: riotAccount.id,
           set: {
@@ -44,22 +47,17 @@ export class RiotAccountService {
   }
 
   /**
-   * @desc rawdataes 에서 riotaccount 추출
+   * @desc rawData 에서 riotAccount 추출 및 Zod 유효성 검사
    */
-  private async parsedRawData(rawDataes: riotAccountData[]): Promise<InsertRiotAccount[]> {
-    const parsedRiotAccounts: InsertRiotAccount[] = [];
+  private parsedRawData(rawData: any): InsertRiotAccount[] {
+    const validatedData = RiotAccountDataArraySchema.parse(rawData);
 
-    for(const rawData of rawDataes) {
-      const puuid = rawData.PUUID;
-      const riotName = rawData.RIOT_ID_GAME_NAME;
-      const riotNameTag = rawData.RIOT_ID_TAG_LINE;
+    const parsedRiotAccounts: InsertRiotAccount[] = validatedData.map((d) => ({
+      id: d.PUUID,
+      riotName: d.RIOT_ID_GAME_NAME,
+      riotNameTag: d.RIOT_ID_TAG_LINE,
+    }));
 
-      parsedRiotAccounts.push({
-        id: puuid,
-        riotName: riotName,
-        riotNameTag: riotNameTag
-      });
-    }
     return parsedRiotAccounts;
   }
 }

--- a/src/services/riotAccount.service.ts
+++ b/src/services/riotAccount.service.ts
@@ -30,7 +30,7 @@ export class RiotAccountService {
         .insert(riotAccount)
         .values(riotAccountData)
         .onConflictDoUpdate({
-          target: riotAccount.id,
+          target: riotAccount.puuid,
           set: {
             riotName: sql`excluded.riot_name`,
             riotNameTag: sql`excluded.riot_name_tag`,
@@ -55,7 +55,7 @@ export class RiotAccountService {
     const validatedData = RiotAccountDataArraySchema.parse(rawData);
 
     const parsedRiotAccounts: InsertRiotAccount[] = validatedData.map((d) => ({
-      id: d.PUUID,
+      puuid: d.PUUID,
       riotName: d.RIOT_ID_GAME_NAME,
       riotNameTag: d.RIOT_ID_TAG_LINE,
     }));

--- a/src/services/riotAccount.service.ts
+++ b/src/services/riotAccount.service.ts
@@ -32,10 +32,12 @@ export class RiotAccountService {
         .onConflictDoUpdate({
           target: riotAccount.id,
           set: {
-            riotName: riotAccount.riotName,
-            riotNameTag: riotAccount.riotNameTag,
+            riotName: sql`excluded.riot_name`,
+            riotNameTag: sql`excluded.riot_name_tag`,
             updateDate: new Date(),
           },
+          where: sql`${riotAccount.riotName} IS DISTINCT FROM excluded.riot_name 
+             OR ${riotAccount.riotNameTag} IS DISTINCT FROM excluded.riot_name_tag`,
         })
         .returning();
 

--- a/src/types/replay.ts
+++ b/src/types/replay.ts
@@ -22,49 +22,4 @@ export interface GetReplaysQuery {
   gameType?: string;
 }
 
-export interface GetRawData {
-  EXP: string;
-  SKIN: string;
-  TEAM: string;
-  ITEM0: string;
-  ITEM1: string;
-  ITEM2: string;
-  ITEM3: string;
-  ITEM4: string;
-  ITEM5: string;
-  ITEM6: string;
-  LEVEL: string;
-  PERK0?: string;
-  PERK1?: string;
-  PERK2?: string;
-  PERK3?: string;
-  PERK4?: string;
-  PERK5?: string;
-  PUUID: string;
-  ASSISTS: string;
-  NUM_DEATHS: string;
-  GOLD_EARNED: string;
-  KEYSTONE_ID: string;
-  PENTA_KILLS: string;
-  TIME_PLAYED: string;
-  VISION_SCORE: string;
-  VISION_BOUGHT: string;
-  TEAM_POSITION: string;
-  MINIONS_KILLED: string;
-  PERK_SUB_STYLE: string;
-  CHAMPIONS_KILLED: string;
-  RIOT_ID_TAG_LINE: string;
-  RIOT_ID_GAME_NAME: string;
-  SUMMONER_SPELL_1?: string;
-  SUMMONER_SPELL_2?: string;
-  TIME_CCING_OTHERS: string;
-  TOTAL_DAMAGE_DEALT_TO_CHAMPIONS: string;
-  TOTAL_DAMAGE_DEALT_TO_BUILDINGS: string;
-  TOTAL_DAMAGE_TAKEN: string;
-  INDIVIDUAL_POSITION: string;
-  NEUTRAL_MINIONS_KILLED: string;
-  NEUTRAL_MINIONS_KILLED_YOUR_JUNGLE: string;
-  NEUTRAL_MINIONS_KILLED_ENEMY_JUNGLE: string;
-}
-
 export type { Replay };

--- a/src/types/replay.ts
+++ b/src/types/replay.ts
@@ -22,4 +22,49 @@ export interface GetReplaysQuery {
   gameType?: string;
 }
 
+export interface GetRawData {
+  EXP: string;
+  SKIN: string;
+  TEAM: string;
+  ITEM0: string;
+  ITEM1: string;
+  ITEM2: string;
+  ITEM3: string;
+  ITEM4: string;
+  ITEM5: string;
+  ITEM6: string;
+  LEVEL: string;
+  PERK0?: string;
+  PERK1?: string;
+  PERK2?: string;
+  PERK3?: string;
+  PERK4?: string;
+  PERK5?: string;
+  PUUID: string;
+  ASSISTS: string;
+  NUM_DEATHS: string;
+  GOLD_EARNED: string;
+  KEYSTONE_ID: string;
+  PENTA_KILLS: string;
+  TIME_PLAYED: string;
+  VISION_SCORE: string;
+  VISION_BOUGHT: string;
+  TEAM_POSITION: string;
+  MINIONS_KILLED: string;
+  PERK_SUB_STYLE: string;
+  CHAMPIONS_KILLED: string;
+  RIOT_ID_TAG_LINE: string;
+  RIOT_ID_GAME_NAME: string;
+  SUMMONER_SPELL_1?: string;
+  SUMMONER_SPELL_2?: string;
+  TIME_CCING_OTHERS: string;
+  TOTAL_DAMAGE_DEALT_TO_CHAMPIONS: string;
+  TOTAL_DAMAGE_DEALT_TO_BUILDINGS: string;
+  TOTAL_DAMAGE_TAKEN: string;
+  INDIVIDUAL_POSITION: string;
+  NEUTRAL_MINIONS_KILLED: string;
+  NEUTRAL_MINIONS_KILLED_YOUR_JUNGLE: string;
+  NEUTRAL_MINIONS_KILLED_ENEMY_JUNGLE: string;
+}
+
 export type { Replay };

--- a/src/types/replay.ts
+++ b/src/types/replay.ts
@@ -1,11 +1,11 @@
-import { Replay } from '../database/schema.js';
+import { Guild, Replay } from '../database/schema.js';
 
 export interface ReplayFileRequest {
   fileName: string;
   fileUrl: string;
   gameType?: string;
   createUser: string;
-  guildId: string;
+  guild: Guild;
 }
 
 export interface ReplayResponse {

--- a/src/types/riotAccount.ts
+++ b/src/types/riotAccount.ts
@@ -1,0 +1,16 @@
+import { RiotAccount } from "../database/schema";
+
+export interface RiotAccountResponse {
+  status: 'success' | 'error';
+  messsage: string;
+  data?: RiotAccount | RiotAccount[] | null;
+}
+
+export interface GetRiotAccountsQuery {
+  page?: number;
+  limit?: number;
+  search?: string;
+  
+}
+
+export type { RiotAccount };


### PR DESCRIPTION
## 작업 개요
리플(replay) 저장 로직 개선 및 구조 리팩토링 진행

## 1. 진행 작업

### 리플 저장 로직 
- Replay 파싱 → rawData 추출
- Guild 저장
- Replay 저장
- Riot Account 저장
- Facade 패턴 적용 (저장 로직 통합 및 관리 구조 개선)

## 2. 기타 작업
- replay_code 생성 로직 수정
- replay 테이블 season 컬럼 추가
- riot_account 스키마 추가 및 수정

## 3. 미흡한 점 수정
- 빈 반환값 수정: replay 객체 반환으로 변경
- 에러 처리 개선: 각 저장 서비스별 try-catch 블록 추가
- 불필요한 주석 삭제 및 해제: validation schema, Response Data 관련 주석 처리
- 잘못된 타입 일관성 수정

## 4. 테스트 
- 따로 테스트 진행은 했지만 산출물 작업은 어떻게 해야될지 방향성을 몰라서 미루어 뒀습니다.
- 정해진 양식이 없다면 임의로 작성 후 메시지 드리겠습니다.

---

## 참고 문서
자세한 내용은 [V2 리플 저장 로직 1차](https://trcgg.atlassian.net/wiki/spaces/SD/pages/170754049/TRC-127+V2+1) 문서를 참고 바랍니다.

하위문서1 [guild 저장 리팩토링](https://trcgg.atlassian.net/wiki/spaces/SD/pages/179601410/TRC-133+Guild?atl_f=PAGETREE)
하위문서2 [Replay rawData 타입 정리 및 에러 처리 개선](https://trcgg.atlassian.net/wiki/spaces/SD/pages/179830788/TRC-134+Replay+rawData)
하위문서3 [Riotaccount 스키마 수정](https://trcgg.atlassian.net/wiki/spaces/SD/pages/179929092/TRC-135+RiotAccount?atl_f=PAGETREE)
