### PR TITLE
V2 리플 저장 로직 2차

### DIFF
--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -177,3 +177,23 @@ export const champion = pgTable('champion', {
     .$onUpdate(() => new Date()),
   isDeleted: boolean('is_deleted').notNull().default(false),
 });
+
+export const guildMember = pgTable('guild_member', {
+  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+  status: char('status', { length: 1}).notNull().default('1'), // 1 가입 2 탈퇴
+  account: varchar('account', {length: 64 }).notNull(), // RiotAccount playerCode
+  main_account: varchar('main_account', { length: 64 }),
+  is_main: boolean('is_main').notNull().default(true),
+  guild_id: varchar('guild_id', { length: 128 }).notNull(),
+  createDate: timestamp('create_date', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updateDate: timestamp('update_date', { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+  isDeleted: boolean('is_deleted').notNull().default(false)
+});
+
+export type GuildMember = typeof guildMember.$inferSelect;
+export type InsertGuildMember = typeof guildMember.$inferInsert;

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -101,3 +101,79 @@ export const customMatch = pgTable('custom_match', {
 
 export type CustomMatch = typeof customMatch.$inferSelect;
 export type InsertCustomMatch = typeof customMatch.$inferInsert;
+
+export const matchParticipant = pgTable('match_participant', {
+  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+  customMatchId: varchar('custom_match_id', { length: 255 })
+    .notNull()
+    .references(() => customMatch.id),
+  puuid: varchar('puuid', { length: 64 })
+    .notNull()
+    .references(() => riotAccount.puuid),
+  championId: varchar('champion_id', { length: 16 })
+    .notNull()
+    .references(() => champion.id),
+  gameTeam: varchar('game_team', { length: 8 }).notNull(),
+  gameResult: varchar('game_result', { length: 8 }).notNull(),
+  position: varchar('position', { length: 16 }).notNull(),
+  kill: integer('kill').notNull(),
+  death: integer('death').notNull(),
+  assist: integer('assist').notNull(),
+  gold: integer('gold').notNull(),
+  ccing: integer('ccing').notNull(),
+  exp: integer('exp').notNull(),
+  timePlayed: integer('time_played').notNull(),
+  totalDamageChampions: integer('total_damage_champions').notNull(),
+  totalDamageDealtToBuildings: integer('total_damage_dealt_to_buildings').notNull(),
+  totalDamageTaken: integer('total_damage_taken').notNull(),
+  visionScore: integer('vision_score').notNull(),
+  visionBought: integer('vision_bought').notNull(),
+  pentaKills: integer('penta_kills'),
+  level: integer('level').notNull(),
+  item0: integer('item0').notNull(),
+  item1: integer('item1').notNull(),
+  item2: integer('item2').notNull(),
+  item3: integer('item3').notNull(),
+  item4: integer('item4').notNull(),
+  item5: integer('item5').notNull(),
+  item6: integer('item6').notNull(),
+  summonerSpell1: integer('summoner_spell_1'),
+  summonerSpell2: integer('summoner_spell_2'),
+  perk0: integer('perk0'),
+  perk1: integer('perk1'),
+  perk2: integer('perk2'),
+  perk3: integer('perk3'),
+  perk4: integer('perk4'),
+  perk5: integer('perk5'),
+  keyStoneId: integer('key_stone_id').notNull(),
+  perkSubStyle: integer('perk_sub_style').notNull(),
+  minionsKilled: integer('minions_killed'),
+  neutralMinionsKilled: integer('neutral_minions_killed'),
+  neutralMinionsKilledYourJungle: integer('neutral_minions_killed_your_jungle'),
+  neutralMinionsKilledEnemyJungle: integer('neutral_minions_killed_enemy_jungle'),
+  createDate: timestamp('create_date', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updateDate: timestamp('update_date', { withTimezone: true })
+    .defaultNow()
+    .notNull()
+    .$onUpdate(() => new Date()),
+  isDeleted: boolean('is_deleted').notNull().default(false),
+});
+
+export type MatchParticipant = typeof matchParticipant.$inferSelect;
+export type InsertMatchParticipant = typeof matchParticipant.$inferInsert;
+
+export const champion = pgTable('champion', {
+  id: varchar('id', { length: 16 }).primaryKey(),
+  champName: varchar('champ_name', { length: 128 }),
+  champNameEng: varchar('champ_name_eng', { length: 128 }),
+  createDate: timestamp('create_date', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updateDate: timestamp('update_date', { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+  isDeleted: boolean('is_deleted').notNull().default(false),
+});

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -74,7 +74,6 @@ export const riotAccount = pgTable('riot_account', {
   .notNull().unique(),
   riotName: varchar('riot_name', { length: 128 }).notNull(),
   riotNameTag: varchar('riot_name_tag', { length: 128 }).notNull(),
-  isMain: boolean('is_main').notNull().default(true),
   createDate: timestamp('create_date').notNull().defaultNow(),
   updateDate: timestamp('update_date')
     .defaultNow()

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -85,3 +85,19 @@ export const riotAccount = pgTable('riot_account', {
 
 export type RiotAccount = typeof riotAccount.$inferSelect;
 export type InsertRiotAccount = typeof riotAccount.$inferInsert;
+
+export const customMatch = pgTable('custom_match', {
+  id: varchar('id', { length: 255 }).primaryKey(),
+  gameType: char('game_type', { length: 1 }).notNull().default('1'),
+  guildId: varchar('guild_id', { length: 128 }).notNull(),
+  season: varchar('season', { length: 32 }).notNull(),
+  createDate: timestamp('create_date').notNull().defaultNow(),
+  updateDate: timestamp('update_date')
+    .defaultNow()
+    .notNull()
+    .$onUpdate(() => new Date()),
+  isDeleted: boolean('is_deleted').notNull().default(false),
+});
+
+export type CustomMatch = typeof customMatch.$inferSelect;
+export type InsertCustomMatch = typeof customMatch.$inferInsert;

--- a/src/facade/replaySave.facade.ts
+++ b/src/facade/replaySave.facade.ts
@@ -3,6 +3,7 @@ import { guildService } from'../services/guild.service.js';
 import { replayService } from '../services/replay.service.js';
 import { riotAccountService } from '../services/riotAccount.service.js';
 import { customMatchService } from '../services/customMatch.service.js';
+import { matchParticipantService } from '../services/matchParticipant.service.js';
 import { Replay, ReplayFileRequest } from '../types/replay.js';
 
 /**
@@ -37,6 +38,9 @@ export class ReplaySaveFacade {
         
         // 내전 저장
         await customMatchService.insertCustomMatch(customMatchData, tx);
+
+        // 내전 참여자 기록 저장 
+        await matchParticipantService.insertMatchParticipants(rawData, customMatchData.id, tx);
 
         return savedReplay;
       });

--- a/src/facade/replaySave.facade.ts
+++ b/src/facade/replaySave.facade.ts
@@ -31,7 +31,7 @@ export class ReplaySaveFacade {
         await riotAccountService.upsertRiotAccount(rawData, tx);
 
         // puuid로 player_code 조회
-        const riotAccounts = await riotAccountService.findRiotAccountsByPuuids(rawData);
+        const riotAccounts = await riotAccountService.findRiotAccountsByPuuids(rawData, tx);
 
         const customMatchData = {
           id: savedReplay.replayCode,

--- a/src/facade/replaySave.facade.ts
+++ b/src/facade/replaySave.facade.ts
@@ -5,6 +5,7 @@ import { riotAccountService } from '../services/riotAccount.service.js';
 import { customMatchService } from '../services/customMatch.service.js';
 import { matchParticipantService } from '../services/matchParticipant.service.js';
 import { Replay, ReplayFileRequest } from '../types/replay.js';
+import { guildMemberService } from '../services/guildMember.service.js';
 
 /**
  * @desc 여러 저장 Service 로직 관리
@@ -29,6 +30,9 @@ export class ReplaySaveFacade {
         // Riot 계정 저장
         await riotAccountService.upsertRiotAccount(rawData, tx);
 
+        // puuid로 player_code 조회
+        const riotAccounts = await riotAccountService.findRiotAccountsByPuuids(rawData);
+
         const customMatchData = {
           id: savedReplay.replayCode,
           gameType: savedReplay.gameType,
@@ -41,6 +45,13 @@ export class ReplaySaveFacade {
 
         // 내전 참여자 기록 저장 
         await matchParticipantService.insertMatchParticipants(rawData, customMatchData.id, tx);
+
+        // 길드 멤버 저장
+        await guildMemberService.insertGuildMember(
+          riotAccounts,
+          savedReplay.guildId,
+          tx
+        );
 
         return savedReplay;
       });

--- a/src/facade/replaySave.facade.ts
+++ b/src/facade/replaySave.facade.ts
@@ -2,6 +2,7 @@ import { db, TransactionType  } from '../database/connectionPool.js';
 import { guildService } from'../services/guild.service.js';
 import { replayService } from '../services/replay.service.js';
 import { riotAccountService } from '../services/riotAccount.service.js';
+import { customMatchService } from '../services/customMatch.service.js';
 import { Replay, ReplayFileRequest } from '../types/replay.js';
 
 /**
@@ -18,9 +19,24 @@ export class ReplaySaveFacade {
       return await db.transaction(async (tx: TransactionType) => {
         const rawData = await replayService.getRawData(fileData);
         
+        // 길드 저장
         await guildService.upsertGuild(fileData.guild, tx);
+        
+        // Replay 저장 (원본 데이터)
         const savedReplay = await replayService.replaySave(fileData, rawData, tx);
+
+        // Riot 계정 저장
         await riotAccountService.upsertRiotAccount(rawData, tx);
+
+        const customMatchData = {
+          id: savedReplay.replayCode,
+          gameType: savedReplay.gameType,
+          guildId: savedReplay.guildId,
+          season: savedReplay.season
+        }
+        
+        // 내전 저장
+        await customMatchService.insertCustomMatch(customMatchData, tx);
 
         return savedReplay;
       });

--- a/src/services/customMatch.service.ts
+++ b/src/services/customMatch.service.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { eq, and, like, desc, sql, is } from 'drizzle-orm';
+import { db, TransactionType } from '../database/connectionPool.js';
+import { customMatch, InsertCustomMatch  } from '../database/schema.js';
+import { BusinessError, SystemError } from '../types/error.js';
+
+/**
+ * @desc 내전 커스텀 게임정보
+ * 
+ */
+export class CustomMatchService {
+  constructor() {}
+
+  /**
+   * @desc 새로운 내전 매치 데이터베이스에 저장
+   */
+  public async insertCustomMatch(newCustomMatchData: InsertCustomMatch, tx: TransactionType) {
+    try {
+      const result = await tx.insert(customMatch).values(newCustomMatchData).returning();
+      return result[0];
+    } catch (error) {
+      console.error('Error inserting CustomMatch', error);
+      throw new SystemError("CustomMatch error while inserting", 500);
+    }
+  }
+  
+}
+
+export const customMatchService = new CustomMatchService();

--- a/src/services/guildMember.service.ts
+++ b/src/services/guildMember.service.ts
@@ -1,0 +1,44 @@
+import { eq, ilike, desc, sql, and } from 'drizzle-orm';
+import { db, TransactionType } from '../database/connectionPool.js';
+import { guildMember, InsertGuildMember, RiotAccount } from '../database/schema.js';
+import { BusinessError, SystemError } from '../types/error.js';
+
+/**
+ * @desc 길드 멤버 서비스 클래스
+ */
+export class GuildMemberService {
+  constructor() {}
+
+  /**
+   * @desc 리플레이 참여 계정들을 길드 멤버로 등록
+   * 'UNIQUE(guild_id, account)' 제약 조건에 따라
+   * 이미 길드에 등록된 계정은 무시
+   *
+   */
+  public async insertGuildMember(
+    riotAccounts: RiotAccount[],
+    guildId: string,
+    tx: TransactionType,
+  ) {
+    const membersToInsert: InsertGuildMember[] = riotAccounts.map((acc) => ({
+      guild_id: guildId,
+      account: acc.playerCode,
+      is_main: true,
+      status: '1',
+    }));
+
+    try {
+      const insertedMembers = await tx
+        .insert(guildMember)
+        .values(membersToInsert)
+        .onConflictDoNothing()
+        .returning();
+      return insertedMembers;
+    } catch (error) {
+      console.error('Error upserting guild members', error);
+      throw new SystemError('GuildMember error while upserting', 500);
+    }
+  }
+}
+
+export const guildMemberService = new GuildMemberService();

--- a/src/services/guildMember.service.ts
+++ b/src/services/guildMember.service.ts
@@ -35,8 +35,8 @@ export class GuildMemberService {
         .returning();
       return insertedMembers;
     } catch (error) {
-      console.error('Error upserting guild members', error);
-      throw new SystemError('GuildMember error while upserting', 500);
+      console.error('Error inserting guild members', error);
+      throw new SystemError('GuildMember error while inserting', 500);
     }
   }
 }

--- a/src/services/matchParticipant.service.ts
+++ b/src/services/matchParticipant.service.ts
@@ -1,0 +1,206 @@
+import { z } from 'zod';
+import { eq, and, like, desc, sql, is, inArray } from 'drizzle-orm'; // 'inArray' 추가
+import { db, TransactionType } from '../database/connectionPool.js';
+import { InsertMatchParticipant, matchParticipant, champion } from '../database/schema.js';
+import { BusinessError, SystemError } from '../types/error.js';
+
+const MatchparticipantSchema = z.object({
+  PUUID: z.string().max(64),
+  SKIN: z.string().max(16),
+  TEAM: z.string().max(8),
+  WIN: z.string().max(8),
+  TEAM_POSITION: z.string().max(16),
+  CHAMPIONS_KILLED: z.string(),
+  NUM_DEATHS: z.string(),
+  ASSISTS: z.string(),
+  GOLD_EARNED: z.string(),
+  TIME_CCING_OTHERS: z.string(),
+  EXP: z.string(),
+  TIME_PLAYED: z.string(),
+  TOTAL_DAMAGE_DEALT_TO_CHAMPIONS: z.string(),
+  TOTAL_DAMAGE_DEALT_TO_BUILDINGS: z.string(),
+  TOTAL_DAMAGE_TAKEN: z.string(),
+  VISION_SCORE: z.string(),
+  VISION_WARDS_BOUGHT_IN_GAME: z.string(),
+  PENTA_KILLS: z.string().optional(),
+  LEVEL: z.string(),
+  ITEM0: z.string(),
+  ITEM1: z.string(),
+  ITEM2: z.string(),
+  ITEM3: z.string(),
+  ITEM4: z.string(),
+  ITEM5: z.string(),
+  ITEM6: z.string(),
+  SUMMONER_SPELL_1: z.string().optional(),
+  SUMMONER_SPELL_2: z.string().optional(),
+  PERK0: z.string().optional(),
+  PERK1: z.string().optional(),
+  PERK2: z.string().optional(),
+  PERK3: z.string().optional(),
+  PERK4: z.string().optional(),
+  PERK5: z.string().optional(),
+  KEYSTONE_ID: z.string(),
+  PERK_SUB_STYLE: z.string(),
+  MINIONS_KILLED: z.string().optional(),
+  NEUTRAL_MINIONS_KILLED: z.string().optional(),
+  NEUTRAL_MINIONS_KILLED_YOUR_JUNGLE: z.string().optional(),
+  NEUTRAL_MINIONS_KILLED_ENEMY_JUNGLE: z.string().optional(),
+});
+
+const MatchparticipantArraySchema = z.array(MatchparticipantSchema);
+
+/**
+ * @desc "blue" 또는 "red"로 변환
+ */
+const mapTeam = (teamId: string): string => {
+  if (teamId === '100') return 'blue';
+  if (teamId === '200') return 'red';
+  return teamId;
+};
+
+/**
+ * @desc 승리 여부 ("Win")를 "승" 또는 "패"로 변환
+ */
+const mapResult = (winStatus: string): string => {
+  return winStatus === 'Win' ? '승' : '패';
+};
+
+/**
+ * @desc 포지션 변환
+ */
+const mapPosition = (position: string): string => {
+  switch (position) {
+    case 'JUNGLE':
+      return 'JUG';
+    case 'BOTTOM':
+      return 'ADC';
+    case 'UTILITY':
+      return 'SUP';
+    case 'MIDDLE':
+      return 'MID';
+    case 'TOP':
+      return 'TOP';
+    default:
+      return position;
+  }
+};
+
+/**
+ * @desc 내전 참여자 서비스 
+ */
+export class MatchParticipantService {
+  constructor() {}
+
+  /**
+   * 여러 참가자 데이터를 DB에 삽입합니다.
+   * @param rawData - API로부터 받은 원본 데이터 배열
+   * @param customMatchId - 이 참가자들이 속한 custom_match의 ID
+   * @param tx - Drizzle 트랜잭션 객체
+   */
+  public async insertMatchParticipants(rawData: any[], customMatchId: string, tx: TransactionType) {
+    try {
+      // 1. rawData를 파싱하고 챔피언 ID로 변환 (await 필요)
+      const newData = await this.parsedMatchParticipant(rawData, customMatchId);
+
+      // 2. 변환된 데이터를 삽입
+      const result = await tx.insert(matchParticipant).values(newData).returning();
+      return result;
+    } catch (error) {
+      console.error('Error inserting MatchParticipants', error);
+      throw new SystemError('Matchparticipants error while inserting', 500);
+    }
+  }
+
+  /**
+   * @desc rawData 배열을 Drizzle 삽입용 InsertMatchParticipant 배열로 파싱하고 변환
+   * @param rawData - Zod 스키마에 의해 검증될 알 수 없는 데이터
+   * @param customMatchId - 이 참가자들이 속한 custom_match의 ID
+   * @returns InsertMatchParticipant 타입의 객체 배열 Promise
+   */
+  private async parsedMatchParticipant(
+    rawData: any,
+    customMatchId: string,
+  ): Promise<InsertMatchParticipant[]> {
+    // Zod를 사용하여 원본 데이터 검증
+    const validatedData = MatchparticipantArraySchema.parse(rawData);
+
+    // 1. 필요한 모든 챔피언 영문 이름(d.SKIN)을 중복 없이 추출합니다.
+    const championEngNames = [...new Set(validatedData.map((d) => d.SKIN).filter(Boolean))];
+
+    // 2. DB 조회를 *단 한 번* 실행하여, 챔피언 영문 이름과 ID 맵
+    const championRecords = await db
+      .select({ id: champion.id, nameEng: champion.champNameEng })
+      .from(champion)
+      .where(inArray(champion.champNameEng, championEngNames));
+
+    // 3. 챔피언 영문 이름을 Key, 챔피언 ID를 Value로 하는 Map
+    const championNameIdMap = new Map<string, string>();
+    for (const record of championRecords) {
+      if (record.nameEng) {
+        championNameIdMap.set(record.nameEng, record.id);
+      }
+    }
+
+    const parseIntOptional = (val: string | undefined): number | undefined => {
+      if (val === undefined || val === null) return undefined;
+      const num = parseInt(val, 10);
+      return isNaN(num) ? undefined : num;
+    };
+
+    const parsedMatchParticipants: InsertMatchParticipant[] = validatedData.map((d) => {
+      const championId = championNameIdMap.get(d.SKIN) || d.SKIN;
+
+      const gameTeam = mapTeam(d.TEAM);
+      const gameResult = mapResult(d.WIN);
+      const position = mapPosition(d.TEAM_POSITION);
+
+      return {
+        customMatchId: customMatchId,
+        puuid: d.PUUID,
+        championId: championId,
+        gameTeam: gameTeam,
+        gameResult: gameResult,
+        position: position,
+        kill: parseInt(d.CHAMPIONS_KILLED),
+        death: parseInt(d.NUM_DEATHS),
+        assist: parseInt(d.ASSISTS),
+        gold: parseInt(d.GOLD_EARNED),
+        ccing: parseInt(d.TIME_CCING_OTHERS),
+        exp: parseInt(d.EXP),
+        timePlayed: parseInt(d.TIME_PLAYED) ,
+        totalDamageChampions: parseInt(d.TOTAL_DAMAGE_DEALT_TO_CHAMPIONS), 
+        totalDamageDealtToBuildings: parseInt(d.TOTAL_DAMAGE_DEALT_TO_BUILDINGS),
+        totalDamageTaken: parseInt(d.TOTAL_DAMAGE_TAKEN),
+        visionScore: parseInt(d.VISION_SCORE),
+        visionBought: parseInt(d.VISION_WARDS_BOUGHT_IN_GAME),
+        pentaKills: parseIntOptional(d.PENTA_KILLS),
+        level: parseInt(d.LEVEL),
+        item0: parseInt(d.ITEM0),
+        item1: parseInt(d.ITEM1),
+        item2: parseInt(d.ITEM2),
+        item3: parseInt(d.ITEM3),
+        item4: parseInt(d.ITEM4),
+        item5: parseInt(d.ITEM5),
+        item6: parseInt(d.ITEM6),
+        summonerSpell1: parseIntOptional(d.SUMMONER_SPELL_1),
+        summonerSpell2: parseIntOptional(d.SUMMONER_SPELL_2),
+        perk0: parseIntOptional(d.PERK0),
+        perk1: parseIntOptional(d.PERK1),
+        perk2: parseIntOptional(d.PERK2),
+        perk3: parseIntOptional(d.PERK3),
+        perk4: parseIntOptional(d.PERK4),
+        perk5: parseIntOptional(d.PERK5),
+        keyStoneId: parseInt(d.KEYSTONE_ID),
+        perkSubStyle: parseInt(d.PERK_SUB_STYLE),
+        minionsKilled: parseIntOptional(d.MINIONS_KILLED),
+        neutralMinionsKilled: parseIntOptional(d.NEUTRAL_MINIONS_KILLED),
+        neutralMinionsKilledYourJungle: parseIntOptional(d.NEUTRAL_MINIONS_KILLED_YOUR_JUNGLE),
+        neutralMinionsKilledEnemyJungle: parseIntOptional(d.NEUTRAL_MINIONS_KILLED_ENEMY_JUNGLE),
+      };
+    });
+
+    return parsedMatchParticipants;
+  }
+}
+
+export const matchParticipantService = new MatchParticipantService();

--- a/src/services/replay.service.ts
+++ b/src/services/replay.service.ts
@@ -64,7 +64,11 @@ export class ReplayService {
    * @desc replay_code 생성 (RPY-YYMMDD-filename-id) 형식
    */
   private async generateReplayCode(fileName: string): Promise<string> {
-    const datePart = new Date().toISOString().split('T')[0];
+    const seoulDateStr = new Date().toLocaleString('sv-SE', {
+      timeZone: 'Asia/Seoul',
+    });
+
+    const datePart = seoulDateStr.split(' ')[0];
     const YYMMDD = datePart.substring(2).replace(/-/g, '');
 
     const prefix = `RPY-${YYMMDD}-${fileName}-`;

--- a/src/services/riotAccount.service.ts
+++ b/src/services/riotAccount.service.ts
@@ -51,18 +51,26 @@ export class RiotAccountService {
   /**
    * 
    * @desc RiotAccount player_code 조회
+   * rawData puuid로 player_code 조회
+   * 트랜잭션
    */
-  public async findRiotAccountsByPuuids(rawData: any[]) {
+  public async findRiotAccountsByPuuids(rawData: any[], tx: TransactionType) {
     const riotAccountDatas = this.parsedRawData(rawData);
 
     const puuids = riotAccountDatas.map(account => account.puuid);
 
-    const result = await db
-      .select()
-      .from(riotAccount)
-      .where(inArray(riotAccount.puuid, puuids));
-    
-    return result;
+    try {
+      const result = await tx
+        .select()
+        .from(riotAccount)
+        .where(inArray(riotAccount.puuid, puuids));
+      
+      return result;
+    } catch (error) {
+      console.error("error while findRiotAccountsByPuuids");
+      throw new SystemError("RiotAccount error while findRiotAccountsByPuuids", 500);
+    }
+
   }
 
   /**

--- a/src/services/riotAccount.service.ts
+++ b/src/services/riotAccount.service.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { eq, and, like, desc, sql, is } from 'drizzle-orm';
+import { eq, and, like, desc, sql, is, inArray} from 'drizzle-orm';
 import { db, TransactionType } from '../database/connectionPool.js';
 import { riotAccount, InsertRiotAccount } from '../database/schema.js';
 import { BusinessError, SystemError } from '../types/error.js';
@@ -46,6 +46,23 @@ export class RiotAccountService {
       console.error('Error upserting RiotAccount', error);
       throw new SystemError('RiotAccount error while upserting', 500);
     }
+  }
+
+  /**
+   * 
+   * @desc RiotAccount player_code 조회
+   */
+  public async findRiotAccountsByPuuids(rawData: any[]) {
+    const riotAccountDatas = this.parsedRawData(rawData);
+
+    const puuids = riotAccountDatas.map(account => account.puuid);
+
+    const result = await db
+      .select()
+      .from(riotAccount)
+      .where(inArray(riotAccount.puuid, puuids));
+    
+    return result;
   }
 
   /**


### PR DESCRIPTION
## 내용
1차에서 마무리 못한 2차 저장 내용

## 주요 작업
- customMatch service 저장 추가
- matchParticipant service 저장 추가
- guildMember service 저장 추가
- facade 패턴 적용

[컨플참고](https://trcgg.atlassian.net/wiki/spaces/SD/pages/193593345/TRC-136+V2+2)

## 그 외
- replay_code 생성에서 날짜 timezone Asia/seoul 설정
- riotAccount puuid를 통해 player_code 가져오는 조회 서비스 추가, 트랜잭션으로 변경
- riotAccount isMain 컬럼 삭제  --> guild_member 에서 본캐 부캐 판별
- 잘못된 ~~주석~~ 문구 -->> 잘못된 로그 문구 수정

## 추후 작업
guildId base64 디코딩