### PR TITLE
핫픽스: 길드조회 불안정 이슈 수정

### DIFF
--- a/src/controllers/discordAuth.controller.ts
+++ b/src/controllers/discordAuth.controller.ts
@@ -5,9 +5,10 @@ import { BusinessError, SystemError } from '../types/error.js';
 import { AuthRequest } from '../middlewares/authHandler.js';
 import { DiscordMemberGuildService } from '../services/discordMemberGuild.service.js';
 import { discordMemberRoleService } from '../services/discordMemberRole.service.js';
-import { DiscordGuildAPIResponse } from '../types/discordAuth.js';
+import { DiscordGuildAPI, DiscordGuildAPIResponse } from '../types/discordAuth.js';
 import { systemConfigService } from '../services/systemConfig.service.js';
 import { getCookieOptions } from '../utils/cookieOptions.js';
+import { ADMIN_ROLES, Role } from '../types/role.js';
 
 const discordAuthService = new DiscordAuthService();
 const discordMemberGuildService = new DiscordMemberGuildService();
@@ -108,7 +109,20 @@ export const getGmokGuilds = async (req: AuthRequest, res: Response<DiscordGuild
 
     // 2. 활성 권한 조회 후 guilds 조회
     const activeRoles = await discordMemberRoleService.getActiveRoles(discordMemberId);
-    const guildsData = await discordMemberGuildService.findUserGmokGuilds(accessToken, activeRoles);
+    const isAdmin = activeRoles.some((r) => ADMIN_ROLES.includes(r.role as Role));
+    let guildsData: DiscordGuildAPI[];
+
+    if (isAdmin) {
+      guildsData = await discordMemberGuildService.findAdminGmokGuilds(activeRoles);
+    } else {
+      const joinedGmokGuilds = await discordMemberGuildService.findJoinedGmokGuilds(accessToken);
+      const ensuredRoles = await discordMemberRoleService.ensureDefaultRolesForGuilds(
+        discordMemberId,
+        joinedGmokGuilds.map((g) => g.id),
+        activeRoles,
+      );
+      guildsData = discordMemberGuildService.applyRolesToGuilds(joinedGmokGuilds, ensuredRoles);
+    }
     res.status(200).json({
       status: 'success',
       message: 'gmok Guilds find successfully',

--- a/src/services/discordAuth.service.ts
+++ b/src/services/discordAuth.service.ts
@@ -10,7 +10,6 @@ import {
   DiscordTokenAPI,
 } from '../types/discordAuth.js';
 import { BusinessError, SystemError } from '../types/error.js';
-import { discordMemberRoleService } from './discordMemberRole.service.js';
 import { fetchWithTimeout } from '../utils/fetchWithTimeout.js';
 import { systemConfigService } from './systemConfig.service.js';
 
@@ -136,9 +135,6 @@ export class DiscordAuthService {
         { ...formattedToken, id: userData.id },
         newAuthData,
       );
-
-      // 5. 최초 로그인 시 기본 권한 삽입 (트랜잭션 외부)
-      await discordMemberRoleService.insertDefaultRolesIfNotExists(userData.id, access_token);
 
       return sessionUid;
     } catch (error) {

--- a/src/services/discordMemberGuild.service.ts
+++ b/src/services/discordMemberGuild.service.ts
@@ -2,7 +2,7 @@ import { GuildService } from './guild.service.js';
 import { Role, ADMIN_ROLES } from '../types/role.js';
 import { DiscordMemberRole } from '../database/schema.js';
 import { SystemError } from '../types/error.js';
-import { DiscordGuildAPI } from '../types/discordAuth.js';
+import { DiscordGuildAPI, DiscordGuildWithoutRole } from '../types/discordAuth.js';
 import { fetchWithTimeout } from '../utils/fetchWithTimeout.js';
 
 const guildService = new GuildService();
@@ -48,7 +48,7 @@ export class DiscordMemberGuildService {
   private async enrichWithNick(
     guilds: Omit<DiscordGuildAPI, 'role' | 'nick'>[],
     accessToken: string,
-  ): Promise<Omit<DiscordGuildAPI, 'role'>[]> {
+  ): Promise<DiscordGuildWithoutRole[]> {
     return Promise.all(
       guilds.map(async (guild) => {
         let nick: string | undefined = undefined;
@@ -65,7 +65,7 @@ export class DiscordMemberGuildService {
             nick = member.nick?.replace(/\s/g, '') ?? fallbackName;
           }
         } catch {
-          // nick 조회 실패 시 undefined
+          // nick은 부가 정보이므로 조회 실패 시 undefined로 둠
         }
 
         return { ...guild, nick };
@@ -74,32 +74,67 @@ export class DiscordMemberGuildService {
   }
 
   /**
-   * @desc 사용자가 가입한 Gmok 길드 목록 + 길드별 권한 반환
-   * - admin(adminNormal 이상): 전체 길드 목록, role은 DB 값 그대로
-   * - 일반 유저: 가입한 Discord 길드 중 Gmok 길드만, 길드별 role
+   * @desc 사용자가 가입한 Discord 길드 중 Gmok에 등록된 길드 목록 조회
+   */
+  public async findJoinedGmokGuilds(accessToken: string): Promise<DiscordGuildWithoutRole[]> {
+    const [gmokGuildsResponse, userDiscordGuilds] = await Promise.all([
+      guildService.findAllGuilds({ page: 1, limit: 1000 }),
+      this.fetchUserGuilds(accessToken),
+    ]);
+
+    const gmokGuildIdSet = new Set(gmokGuildsResponse.result.map((g) => g.id));
+    const gmokGuilds = userDiscordGuilds.filter((g) => gmokGuildIdSet.has(g.id));
+
+    return this.enrichWithNick(gmokGuilds, accessToken);
+  }
+
+  /**
+   * @desc Admin 권한 사용자가 접근 가능한 전체 Gmok 길드 목록 조회
+   */
+  public async findAdminGmokGuilds(activeRoles: DiscordMemberRole[]): Promise<DiscordGuildAPI[]> {
+    const gmokGuildsResponse = await guildService.findAllGuilds({ page: 1, limit: 1000 });
+    const roleByGuildId = new Map(activeRoles.map((r) => [r.guildId, r.role as Role]));
+    const adminRole = roleByGuildId.get(null) ?? ('adminNormal' as Role);
+
+    return gmokGuildsResponse.result.map((g) => ({
+      id: g.id,
+      name: g.name,
+      icon: '',
+      banner: '',
+      role: adminRole,
+    }));
+  }
+
+  /**
+   * @desc Gmok 길드 목록에 길드별 권한 정보 적용
+   */
+  public applyRolesToGuilds(
+    guilds: DiscordGuildWithoutRole[],
+    activeRoles: DiscordMemberRole[],
+  ): DiscordGuildAPI[] {
+    const roleByGuildId = new Map(activeRoles.map((r) => [r.guildId, r.role as Role]));
+
+    return guilds.map((g) => ({
+      ...g,
+      role: roleByGuildId.get(g.id) ?? ('userNormal' as Role),
+    }));
+  }
+
+  /**
+   * @desc 사용자가 접근 가능한 Gmok 길드 목록과 길드별 권한 반환
    */
   public async findUserGmokGuilds(
     accessToken: string,
     activeRoles: DiscordMemberRole[],
   ): Promise<DiscordGuildAPI[]> {
-    const gmokGuildsResponse = await guildService.findAllGuilds({ page: 1, limit: 1000 });
-    const allGmokGuilds = gmokGuildsResponse.result;
-
     const isAdmin = activeRoles.some((r) => ADMIN_ROLES.includes(r.role as Role));
-    const roleByGuildId = new Map(activeRoles.map((r) => [r.guildId, r.role as Role]));
 
     if (isAdmin) {
-      const adminRole = roleByGuildId.get(null) ?? ('adminNormal' as Role);
-      return allGmokGuilds.map((g) => ({ id: g.id, name: g.name, icon: '', banner: '', role: adminRole }));
+      return this.findAdminGmokGuilds(activeRoles);
     }
 
-    const userDiscordGuilds = await this.fetchUserGuilds(accessToken);
-    const gmokGuildIdSet = new Set(allGmokGuilds.map((g) => g.id));
-
-    const gmokGuilds = userDiscordGuilds.filter((g) => gmokGuildIdSet.has(g.id));
-    const guildsWithNick = await this.enrichWithNick(gmokGuilds, accessToken);
-
-    return guildsWithNick.map((g) => ({ ...g, role: roleByGuildId.get(g.id) ?? ('userNormal' as Role) }));
+    const guilds = await this.findJoinedGmokGuilds(accessToken);
+    return this.applyRolesToGuilds(guilds, activeRoles);
   }
 }
 

--- a/src/services/discordMemberRole.service.ts
+++ b/src/services/discordMemberRole.service.ts
@@ -1,10 +1,7 @@
 import { eq, and, or, isNull } from 'drizzle-orm';
 import { db } from '../database/connectionPool.js';
-import { discordMemberRole } from '../database/schema.js';
+import { DiscordMemberRole, discordMemberRole } from '../database/schema.js';
 import { ADMIN_ROLES, Role } from '../types/role.js';
-import { DiscordMemberGuildService } from './discordMemberGuild.service.js';
-
-const discordMemberGuildService = new DiscordMemberGuildService();
 
 /**
  * @desc discord_member_role DB 조작 서비스
@@ -37,29 +34,28 @@ export class DiscordMemberRoleService {
   }
 
   /**
-   * @desc 로그인 시 기본 권한(userNormal) 삽입
-   * - 이미 권한이 있는 길드는 스킵
-   * - 권한이 없는 길드에만 userNormal 삽입
+   * @desc 가입한 Gmok 길드 중 권한이 없는 길드에 기본 권한(userNormal) 삽입
    */
-  public async insertDefaultRolesIfNotExists(memberId: string, accessToken: string): Promise<void> {
-    const gmokGuilds = await discordMemberGuildService.findUserGmokGuilds(accessToken, []);
+  public async ensureDefaultRolesForGuilds(
+    memberId: string,
+    guildIds: string[],
+    activeRoles: DiscordMemberRole[],
+  ): Promise<DiscordMemberRole[]> {
+    const isAdmin = activeRoles.some((r) => ADMIN_ROLES.includes(r.role as Role));
+    if (isAdmin) return activeRoles;
 
-    if (gmokGuilds.length === 0) return;
+    const uniqueGuildIds = [...new Set(guildIds)];
+    const existingGuildIds = new Set(activeRoles.map((r) => r.guildId));
+    const missingGuildIds = uniqueGuildIds.filter((guildId) => !existingGuildIds.has(guildId));
 
-    const existing = await this.getActiveRoles(memberId);
+    if (missingGuildIds.length === 0) return activeRoles;
 
-    // Admin 권한이 있으면 길드별 userNormal 삽입 불필요
-    const isAdmin = existing.some((r) => ADMIN_ROLES.includes(r.role as Role));
-    if (isAdmin) return;
+    await db
+      .insert(discordMemberRole)
+      .values(missingGuildIds.map((guildId) => ({ memberId, role: 'userNormal', guildId })))
+      .onConflictDoNothing();
 
-    const existingGuildIds = new Set(existing.map((r) => r.guildId));
-    const newGuilds = gmokGuilds.filter((g) => !existingGuildIds.has(g.id));
-
-    if (newGuilds.length === 0) return;
-
-    await db.insert(discordMemberRole).values(
-      newGuilds.map((g) => ({ memberId, role: 'userNormal', guildId: g.id })),
-    );
+    return this.getActiveRoles(memberId);
   }
 }
 

--- a/src/types/discordAuth.ts
+++ b/src/types/discordAuth.ts
@@ -42,6 +42,8 @@ export interface DiscordGuildAPI {
   role: Role;
 }
 
+export type DiscordGuildWithoutRole = Omit<DiscordGuildAPI, 'role'>;
+
 // Discord API Guild 응답 타입
 export interface DiscordGuildAPIResponse {
   status: 'success' | 'error';


### PR DESCRIPTION
Discord 권한 패치 이후 로그인 콜백에서 수행되던 기본 권한 생성 로직을 제거하고,
로그인 완료 후 /api/auth/gmokGuilds 조회 시점에 길드별 권한을 보정하도록 개선

https://trcgg.atlassian.net/browse/TRC-205 참고