### PR TITLE
Add MMR service and backend design documentation

### DIFF
--- a/docs/MMR_BACKEND_DESIGN.md
+++ b/docs/MMR_BACKEND_DESIGN.md
@@ -1,0 +1,549 @@
+# MMR 백엔드 설계 (확정본)
+
+> 이 문서는 `loltrix_be`(백엔드) 관점의 MMR 통합 설계 확정본이다.
+> 짝 문서: `docs/MMR_SERVICE_DESIGN.md` (MMR 서비스 측 설계 — `trcgg/gmok_mmr`에 반영 대상)
+
+## 0. 목적과 범위
+
+길드 단위 MMR 구독 서비스와 통계 집계 기반을 추가한다.
+운영 중인 `match_participant` 테이블은 그대로 유지하고, 통계/MMR 공통 입력인 `match_participant_metric`을 별도로 둔다.
+MMR은 **신규 경기 단위 incremental**로 계산하고, 전체 재계산(RECALC)은 예외 상황에서만 수행한다.
+
+## 1. 아키텍처 결정 사항 (10개)
+
+| # | 항목 | 결정 |
+|---|---|---|
+| 1 | MMR 계산 흐름 | **Incremental 중심.** 단일 경기 API 활성화. RECALC는 (신규 구독 init, 시즌 변경, 산식 변경, 운영자 수동) 시에만. |
+| 2 | 포지션별 state | **백엔드 저장.** `player_mmr_summary`에 포지션별 컬럼 추가. incremental의 전제 조건. |
+| 3 | MMR 서비스 배포 | **별도 인스턴스 상시.** 백엔드와 분리된 노드에서 FastAPI 상시 가동. |
+| 4 | 컬럼/식별자/enum 통일 | **백엔드 contract를 SoT로** 두고 MMR 코드(`gmok_mmr`) 내부를 일괄 rename. |
+| 5 | Incremental 트리거 | **5분 주기 묶음 worker.** wait 상태의 custom_match를 도착순으로 batch 호출. |
+| 6 | 신규 구독 init | **구독 즉시 RECALC 트리거.** wait_init은 사실상 잠깐만 보임. |
+| 7 | Baseline 데이터 부족 | **`INSUFFICIENT_DATA` 에러 반환.** 시즌 초기는 baseline 미준비 상태로 정확히 표현. |
+| 8 | 경기 필터 | **백엔드 metric의 `is_mmr_eligible boolean`.** 통계는 포함, MMR만 제외. |
+| 9 | 재구독 데이터 정리 | **Soft delete + 30일 유예 후 hard delete.** |
+| 10 | mmr_history | **처음부터 monthly range partition.** |
+
+## 2. 식별자 / Enum / 단위
+
+### 식별자 (백엔드 ↔ MMR 서비스 공통)
+| 항목 | 값 |
+|---|---|
+| 유저 식별자 | `puuid` |
+| 경기 식별자 | `custom_match_id` |
+| 길드 식별자 | `guild_id` |
+| 시즌 식별자 | `season` |
+| 계산 실행 식별자 | `calculation_id` |
+| baseline 식별자 | `baseline_version` |
+| feature 추출 버전 | `feature_version` |
+
+부계정 통합은 MMR에서 고려하지 않는다.
+
+### Enum
+| 필드 | 값 |
+|---|---|
+| `position` | `TOP`, `JUG`, `MID`, `ADC`, `SUP` |
+| `game_team` | `blue`, `red` |
+| `game_result` | `1`(승리), `0`(패배) |
+
+### 시간 / 수치
+| 필드 | 단위 |
+|---|---|
+| `time_played` | 초 |
+| `played_at` | ISO 8601 datetime string (timezone 포함) |
+| `calculated_at` | ISO 8601 datetime string |
+| MMR 값 | integer |
+
+## 3. 상태 정의
+
+### `guild_subscription.status`
+```
+active | inactive | cancelled
+```
+
+### `guild_mmr_state.status`
+```
+idle | wait_init | ready | error
+```
+| 상태 | 의미 |
+|---|---|
+| `idle` | MMR 상태 없음/초기 상태 |
+| `wait_init` | RECALC job 큐잉됨, 아직 ready 아님 |
+| `ready` | MMR 사용 가능 |
+| `error` | 마지막 init/배치 실패 |
+
+### `mmr_job.status`
+```
+wait | run | done | fail | cancel
+```
+- `job_type`: `INCREMENTAL_BATCH`, `RECALC`, `BASELINE`, `CLEANUP`
+- 최대 3회 재시도 (`max_attempts=3`)
+- 워커 픽업 시 `SELECT ... FOR UPDATE SKIP LOCKED` 사용
+
+### `custom_match_mmr_status.status`
+```
+wait | done | fail | skip
+```
+| 상태 | 의미 |
+|---|---|
+| `wait` | 아직 MMR 반영 안 됨 |
+| `done` | 최신 incremental/RECALC에 반영됨 |
+| `fail` | 처리 실패 |
+| `skip` | 삭제 또는 `is_mmr_eligible=false`로 제외 |
+
+## 4. 핵심 흐름
+
+### 4.1 리플레이 업로드 흐름
+
+```mermaid
+flowchart TD
+  A[리플레이 업로드] --> B[replay 저장]
+  B --> C[custom_match 저장]
+  C --> D[match_participant 저장]
+  D --> E[match_participant_metric 생성/갱신]
+  E --> F{guild MMR 구독 active?}
+  F -- 아니오 --> Z[업로드 완료]
+  F -- 예 --> G[custom_match_mmr_status = wait]
+  G --> Z
+```
+
+업로드 시점에 MMR 서비스 호출 없음.
+
+### 4.2 5분 주기 Incremental Worker
+
+```mermaid
+sequenceDiagram
+  participant Cron as 5분 cron
+  participant Worker as Incremental Worker
+  participant DB as DB
+  participant MMR as MMR 서비스
+
+  Cron->>Worker: 5분 tick
+  Worker->>DB: 구독 active + wait 상태 custom_match 조회 (played_at asc)
+  loop 길드별 그룹
+    Worker->>DB: pre_match_user_summary 조회 (포지션별 state 포함)
+    Worker->>DB: active baseline 조회
+    Worker->>MMR: POST /v1/mmr/matches/calculate (단일 경기 1개씩)
+    MMR-->>Worker: match_results, updated_user_summary, mmr_history
+    Worker->>DB: match_mmr_result/mmr_history/player_mmr_summary upsert (트랜잭션)
+    Worker->>DB: custom_match_mmr_status = done
+  end
+  Worker->>DB: INCREMENTAL_BATCH job done
+```
+
+- 한 5분 tick 내에서도 길드별로 묶고, 길드 내에서는 `played_at` 오름차순으로 **반드시 순차 처리**(MMR 누적 순서가 의미를 가짐).
+- 같은 길드 내 동시 worker 픽업 방지: `mmr_job`에 `unique(job_type, guild_id, status=run)` 가정 + advisory lock.
+
+### 4.3 신규 구독 init 흐름
+
+```mermaid
+flowchart TD
+  A[구독 시작 API] --> B[guild_subscription = active]
+  B --> C[guild_mmr_state = wait_init]
+  C --> D[RECALC job wait 생성]
+  D --> E[Worker가 즉시 픽업]
+  E --> F[기존 match metric 전체 조회]
+  F --> G[POST /v1/mmr/recalculate]
+  G --> H[결과 저장 + player_mmr_summary 갱신]
+  H --> I[guild_mmr_state = ready]
+```
+
+구독 → ready까지 일반적으로 수 분 내 도달 목표.
+
+### 4.4 RECALC 트리거 시점
+1. **신규 구독 init**: 자동
+2. **시즌 변경**: 자동(새 시즌 키로 신규 state 생성)
+3. **알고리즘/baseline 변경 후 보정**: 운영자 수동
+4. **사고 복구**: 운영자 수동
+
+> 일상 운영에서는 RECALC를 돌리지 않는다. Incremental만으로 정합 유지.
+
+### 4.5 일일 정합성 체크 (10시 KST)
+RECALC가 아닌 **검증/정리 작업**:
+1. `custom_match_mmr_status`에서 24시간 이상 `wait`인 row 알람
+2. `is_deleted=true`인 custom_match의 `custom_match_mmr_status = skip` 정리
+3. 재구독 soft delete 30일 경과분 hard delete
+4. 메트릭/baseline 정합성 sample 검사(선택)
+
+## 5. DB 스키마 (드리즐 신규 추가분)
+
+### 5.1 `guild_subscription`
+| 컬럼 | 타입 | 비고 |
+|---|---|---|
+| id | uuid PK | |
+| guild_id | varchar(128) FK → guild.id | |
+| service_key | varchar(32) | 예: `MMR` |
+| status | varchar(16) | `active`/`inactive`/`cancelled` |
+| enabled_at | timestamptz | |
+| ended_at | timestamptz nullable | |
+| metadata | jsonb | |
+| create_date / update_date | timestamptz | |
+
+제약: `unique(guild_id, service_key)`
+
+### 5.2 `guild_mmr_state`
+| 컬럼 | 타입 | 비고 |
+|---|---|---|
+| id | uuid PK | |
+| guild_id | varchar(128) | |
+| season | varchar(32) | |
+| status | varchar(16) | `idle`/`wait_init`/`ready`/`error` |
+| initialized_at | timestamptz nullable | |
+| last_calculation_id | varchar(64) nullable | |
+| last_job_id | uuid nullable | |
+| error_message | text nullable | |
+| create_date / update_date | timestamptz | |
+
+제약: `unique(guild_id, season)`
+
+### 5.3 `mmr_baseline`
+| 컬럼 | 타입 | 비고 |
+|---|---|---|
+| id | uuid PK | |
+| season | varchar(32) | |
+| baseline_version | varchar(32) | |
+| mmr_baseline | jsonb | f1_mean, f2_mean 등 |
+| game_impact_baseline | jsonb | position_weights, outcome_stats |
+| metadata | jsonb | match_count, row_count, calculated_at |
+| is_active | boolean | 시즌별 active 1개 |
+| calculated_at | timestamptz | |
+| create_date / update_date | timestamptz | |
+
+제약: `unique(season, baseline_version)` + `partial unique(season) where is_active = true`
+
+### 5.4 `mmr_job`
+| 컬럼 | 타입 | 비고 |
+|---|---|---|
+| id | uuid PK | |
+| guild_id | varchar(128) nullable | INCREMENTAL/RECALC만 채움 |
+| season | varchar(32) nullable | |
+| job_type | varchar(32) | `INCREMENTAL_BATCH`/`RECALC`/`BASELINE`/`CLEANUP` |
+| status | varchar(16) | `wait`/`run`/`done`/`fail`/`cancel` |
+| attempts | int default 0 | |
+| max_attempts | int default 3 | |
+| scheduled_at | timestamptz | |
+| started_at / finished_at | timestamptz nullable | |
+| calculation_id | varchar(64) nullable | |
+| baseline_version | varchar(32) nullable | |
+| payload | jsonb nullable | target custom_match_id 리스트 등 |
+| error_message | text nullable | |
+| create_date / update_date | timestamptz | |
+
+인덱스:
+- `(status, scheduled_at) where status in ('wait','run')`
+- `(guild_id, job_type, status)`
+
+### 5.5 `custom_match_mmr_status`
+| 컬럼 | 타입 | 비고 |
+|---|---|---|
+| custom_match_id | varchar(255) PK | FK → custom_match.id |
+| guild_id | varchar(128) | |
+| season | varchar(32) | |
+| status | varchar(16) | `wait`/`done`/`fail`/`skip` |
+| job_id | uuid nullable | |
+| calculation_id | varchar(64) nullable | |
+| baseline_version | varchar(32) nullable | |
+| error_message | text nullable | |
+| calculated_at | timestamptz nullable | |
+| create_date / update_date | timestamptz | |
+
+인덱스: `(guild_id, season, status)`
+
+### 5.6 `match_participant_metric`
+통계/MMR 공통 입력. `replay.raw_data` + `custom_match` + `match_participant` + `riot_account` 정제 결과.
+
+| 컬럼 | 타입 | 비고 |
+|---|---|---|
+| id | bigserial PK | |
+| match_participant_id | int FK → match_participant.id | |
+| custom_match_id | varchar(255) | |
+| guild_id | varchar(128) | |
+| season | varchar(32) | |
+| puuid | varchar(128) | |
+| champion_id | varchar(16) | |
+| position | varchar(8) | TOP/JUG/MID/ADC/SUP |
+| game_team | varchar(8) | blue/red |
+| game_result | smallint | 0/1 |
+| time_played | int | 초 |
+| kill / death / assist | int | |
+| gold / ccing / exp | int | |
+| total_damage_champions | int | |
+| total_damage_dealt_to_buildings | int | |
+| total_damage_taken | int | |
+| vision_score / vision_bought | int | |
+| minions_killed | int | |
+| neutral_minions_killed | int | |
+| wards_placed / wards_killed | int | |
+| time_spent_dead | int | |
+| heal_on_teammates / shield_on_teammates | int | |
+| **is_mmr_eligible** | boolean | 기본 true. `time_played < 300`(5분) 또는 remake/AFK 기준 시 false |
+| feature_version | varchar(16) | |
+| played_at | timestamptz | |
+| create_date / update_date | timestamptz | |
+
+제약:
+- `unique(match_participant_id, feature_version)`
+- 운영 1단계에서는 `unique(match_participant_id)`로 시작 가능 (feature_version은 단일)
+
+인덱스:
+- `(guild_id, season, played_at desc)`
+- `(custom_match_id)`
+- `(puuid, season)`
+
+**참고**: `riot_name`, `riot_name_tag`은 여기 저장하지 않는다 — 표시용은 `riot_account` JOIN.
+
+### 5.7 `match_mmr_result`
+| 컬럼 | 타입 | 비고 |
+|---|---|---|
+| id | bigserial PK | |
+| calculation_id | varchar(64) | |
+| baseline_version | varchar(32) | |
+| guild_id | varchar(128) | |
+| season | varchar(32) | |
+| custom_match_id | varchar(255) | |
+| match_participant_id | int | |
+| puuid | varchar(128) | |
+| position | varchar(8) | |
+| game_result | smallint | |
+| pre_game_mmr | int | 포지션 MMR (incremental 기준) |
+| mmr_change | int | |
+| post_game_mmr | int | |
+| expected_score | numeric(6,4) | |
+| actual_score | numeric(6,4) | |
+| relative_factor | numeric(6,4) | |
+| personal_factor | numeric(6,4) | |
+| final_factor | numeric(6,4) | |
+| calculated_at | timestamptz | |
+
+제약: `unique(calculation_id, match_participant_id)` (멱등 upsert 보장)
+
+인덱스: `(guild_id, season, puuid, calculated_at desc)`, `(custom_match_id)`
+
+### 5.8 `mmr_history` ⭐ partitioned
+`create_date` 기준 monthly range partition. 매월 1일 cron으로 다음달 partition 미리 생성.
+
+| 컬럼 | 타입 | 비고 |
+|---|---|---|
+| id | bigserial | PK 일부 |
+| guild_id | varchar(128) | |
+| season | varchar(32) | |
+| puuid | varchar(128) | |
+| custom_match_id | varchar(255) | |
+| position | varchar(8) | |
+| history_type | varchar(32) | `MATCH_RESULT`/`RECALC_RESET`/`SUBSCRIPTION_RESTORE` |
+| mmr_delta | int | |
+| before_mmr | int | total MMR |
+| after_mmr | int | total MMR |
+| before_pos_mmr | int | 포지션 MMR |
+| after_pos_mmr | int | 포지션 MMR |
+| source_calculation_id | varchar(64) | |
+| reason | text nullable | |
+| create_date | timestamptz | partition key |
+
+PK: `(id, create_date)` (partitioned table 요구)
+인덱스(per partition): `(guild_id, season, puuid, create_date desc)`
+
+### 5.9 `player_mmr_summary` ⭐ 포지션별 컬럼 포함
+유저별 현재 MMR. **incremental의 전제**.
+
+| 컬럼 | 타입 | 비고 |
+|---|---|---|
+| guild_id | varchar(128) | PK 일부 |
+| season | varchar(32) | PK 일부 |
+| puuid | varchar(128) | PK 일부 |
+| total_mmr | int | weighted by games |
+| total_games | int | |
+| total_wins | int | |
+| top_mmr / top_games / top_wins | int | 포지션별 |
+| jug_mmr / jug_games / jug_wins | int | |
+| mid_mmr / mid_games / mid_wins | int | |
+| adc_mmr / adc_games / adc_wins | int | |
+| sup_mmr / sup_games / sup_wins | int | |
+| calculation_id | varchar(64) | 마지막 반영 |
+| baseline_version | varchar(32) | |
+| is_deleted | boolean default false | 재구독 soft delete용 |
+| deleted_at | timestamptz nullable | |
+| update_date | timestamptz | |
+
+PK: `(guild_id, season, puuid)`
+인덱스: `(guild_id, season, total_mmr desc) where is_deleted = false` (리더보드용)
+
+**`overall_winrate`는 저장하지 않는다.** `total_wins / total_games`로 즉시 계산.
+
+## 6. 백엔드 책임 / MMR 서비스 책임
+
+### 백엔드 책임
+- 리플레이 원본 저장, raw_data 보관
+- `match_participant_metric` 정제(`is_mmr_eligible` 판정 포함)
+- baseline 저장 및 active baseline 관리
+- MMR 서비스 호출(incremental / RECALC / baseline)
+- 결과 저장: `match_mmr_result`, `mmr_history`, `player_mmr_summary`
+- 구독 상태, job queue 관리
+- 5분 incremental worker, cleanup cron
+
+### MMR 서비스 책임
+- payload 검증
+- baseline 계산
+- 단일 경기 incremental 계산
+- 전체 RECALC 계산
+- `mmr_history` 항목 생성
+
+## 7. is_mmr_eligible 판정 기준 (v1)
+
+기본값 `true`. 다음 중 하나라도 해당하면 `false`:
+1. `time_played < 300` (5분 미만 = 조기항복)
+2. `total_damage_champions == 0` 그리고 `kill + assist == 0` (AFK 의심)
+3. 운영자 수동 제외 표시(메타 컬럼 별도 또는 system_config 기반 룰)
+
+`is_mmr_eligible=false`인 row가 한 경기에 1명이라도 있으면 → 해당 `custom_match` 전체를 MMR 대상에서 제외(`custom_match_mmr_status = skip`). 단일 경기 구조 검증(10명/포지션 2명/승패) 충족 불가하기 때문.
+
+## 8. 신규 구독 / 해지 / 재구독 / 시즌 변경
+
+### 신규 구독
+1. `guild_subscription.status = active`
+2. `guild_mmr_state.status = wait_init`
+3. `RECALC` job 즉시 생성(`status=wait`)
+4. worker가 픽업 → 완료 시 `guild_mmr_state.status = ready`
+
+### 구독 해지
+- `guild_subscription.status = inactive`
+- 기존 MMR 데이터는 **삭제하지 않음** (조회만 차단)
+
+### 재구독
+- 기존 길드/시즌 MMR 데이터에 `is_deleted = true`, `deleted_at = now()` 마킹
+- 30일 내 다시 구독 → restore (계산 없이 `is_deleted = false`로 복구) + 보강 RECALC
+- 30일 경과 → `CLEANUP` job이 hard delete
+- soft delete 대상: `match_mmr_result`, `mmr_history`, `player_mmr_summary`, `custom_match_mmr_status`
+- `match_participant_metric`은 통계 공용이므로 영향 없음
+
+### 시즌 변경
+- 새 `season`으로 `guild_mmr_state` 신규 생성
+- 새 `mmr_baseline` 계산 필요(`INSUFFICIENT_DATA`면 명시적 에러)
+- 신규 RECALC 자동 트리거
+- 이전 시즌 데이터는 그대로 보관
+
+## 9. 조회 API 응답 정책
+
+```json
+{
+  "available": false,
+  "status": "wait_init",
+  "message": "MMR 초기 계산 진행 중입니다.",
+  "data": null
+}
+```
+
+| guild 상태 | available | data |
+|---|---|---|
+| 구독 없음/inactive | false | null |
+| wait_init | false | null |
+| ready | true | MMR 데이터 |
+| error | false | null + 운영 로그 알람 |
+
+사용자 노출 메시지는 internal status와 분리(예: `error` → 사용자에게는 "일시적 처리 지연"으로 표시).
+
+## 10. 멱등성 / 트랜잭션 / 동시성
+
+### 멱등성
+- 모든 결과 저장은 `unique(calculation_id, match_participant_id)` 기반 upsert.
+- MMR 서비스 응답 중복/재시도해도 row 중복 안 생김.
+
+### 트랜잭션 경계
+incremental 1경기당 단일 트랜잭션:
+```
+BEGIN;
+  UPSERT match_mmr_result (calculation_id, match_participant_id) ...
+  INSERT mmr_history ...
+  UPSERT player_mmr_summary ...
+  UPDATE custom_match_mmr_status SET status='done' ...
+COMMIT;
+```
+
+### 동시성
+- `mmr_job` 픽업: `SELECT ... FROM mmr_job WHERE status='wait' ORDER BY scheduled_at FOR UPDATE SKIP LOCKED LIMIT 1`
+- 같은 길드의 INCREMENTAL_BATCH 중복 픽업 방지: `pg_advisory_xact_lock(hashtext(guild_id))`
+
+## 11. 인덱스 마스터 목록
+
+```sql
+-- match_participant_metric
+CREATE INDEX ON match_participant_metric (guild_id, season, played_at DESC);
+CREATE INDEX ON match_participant_metric (custom_match_id);
+CREATE INDEX ON match_participant_metric (puuid, season);
+
+-- mmr_job
+CREATE INDEX ON mmr_job (status, scheduled_at) WHERE status IN ('wait','run');
+CREATE INDEX ON mmr_job (guild_id, job_type, status);
+
+-- custom_match_mmr_status
+CREATE INDEX ON custom_match_mmr_status (guild_id, season, status);
+
+-- match_mmr_result
+CREATE INDEX ON match_mmr_result (guild_id, season, puuid, calculated_at DESC);
+CREATE INDEX ON match_mmr_result (custom_match_id);
+
+-- mmr_history (per partition)
+CREATE INDEX ON mmr_history_YYYYMM (guild_id, season, puuid, create_date DESC);
+
+-- player_mmr_summary
+CREATE INDEX ON player_mmr_summary (guild_id, season, total_mmr DESC)
+  WHERE is_deleted = false;
+```
+
+## 12. API 호출 정리 (백엔드 → MMR 서비스)
+
+| 시점 | API | Job 종류 |
+|---|---|---|
+| 5분 cron tick (incremental) | `POST /v1/mmr/matches/calculate` (경기당 1회) | INCREMENTAL_BATCH |
+| 구독 즉시 / 시즌 변경 / 수동 | `POST /v1/mmr/recalculate` | RECALC |
+| 시즌 시작 시 / 운영자 baseline 갱신 | `POST /v1/mmr/baselines/calculate` | BASELINE |
+
+자세한 payload는 `docs/MMR_SERVICE_DESIGN.md` 참고.
+
+## 13. 운영자 API (관리자 전용)
+
+| 메서드 | 경로 | 설명 |
+|---|---|---|
+| POST | `/admin/mmr/recalc` | guild+season RECALC 강제 |
+| POST | `/admin/mmr/baseline` | 시즌 baseline 강제 재계산 |
+| GET  | `/admin/mmr/jobs` | job queue 상태 조회 |
+| POST | `/admin/mmr/jobs/{id}/retry` | 실패 job 재시도 |
+| POST | `/admin/mmr/jobs/{id}/cancel` | job 취소 |
+
+## 14. 캐파 가정 / 확장성
+
+| 시점 | 길드 | 일 경기 | 일 metric row | 일 incremental 호출 | 1년 누적 history |
+|---|---|---|---|---|---|
+| 현재 | 6 | 40 | 400 | ≤40 (5분 tick × 길드) | ~146k |
+| 목표 | 20 | 200 | 2,000 | ≤200 | ~730k |
+
+- 5분 worker tick 1회당 평균 처리량: 1~5경기. HTTP 호출 ~5건. 1GB Lightsail로 견딜 만함.
+- 20길드 도달 전 서버 1단계 이전(2GB+) 권장. **Postgres만 분리해도 큰 폭으로 안정.**
+
+## 15. 구현 순서
+
+1. DB 마이그레이션 작성 (이 문서의 5장 기준)
+2. Drizzle schema 추가
+3. `match_participant_metric` 정제 service + `is_mmr_eligible` 판정 로직
+4. `mmr_baseline` 저장/조회 + active baseline service
+5. `mmr_job` queue + worker 골격 (advisory lock + SKIP LOCKED)
+6. MMR 서비스 client (axios) — 백엔드 contract 기준 payload 빌더
+7. 구독 시작/해지/재구독 API + 즉시 RECALC 트리거
+8. 5분 cron incremental worker
+9. 결과 저장 service (멱등 upsert + 단일 트랜잭션)
+10. 조회 API (`available/status/data` 포맷)
+11. 운영자 API
+12. monthly partition cron + cleanup cron (재구독 30일 만료)
+13. 통합 테스트: contract JSON 1쌍으로 백엔드 → MMR 서비스 end-to-end
+
+## 16. 리스크 요약
+
+| 리스크 | 대응 |
+|---|---|
+| MMR 서비스 다운 | wait 상태 유지, 5분 tick에서 재시도(최대 3회). 알람 |
+| 1GB 메모리 | MMR 서비스는 별도 인스턴스, raw_data 절대 미전송 |
+| 동시 worker | SKIP LOCKED + advisory lock |
+| baseline 데이터 부족 | INSUFFICIENT_DATA 명시. 새 시즌 진입 운영 가이드 필요 |
+| history 폭증 | monthly partition + 시즌별 archive 검토 |
+| 재구독 사고 | soft delete 30일 유예 |
+| 컬럼명 표류 | contract test 1쌍을 백엔드 CI에 박음 |

--- a/docs/MMR_SERVICE_DESIGN.md
+++ b/docs/MMR_SERVICE_DESIGN.md
@@ -1,0 +1,552 @@
+# MMR 서비스 설계 (확정본)
+
+> 이 문서는 `trcgg/gmok_mmr`(MMR 서비스) 관점의 설계 확정본이다.
+> 짝 문서: `docs/MMR_BACKEND_DESIGN.md` (백엔드 측 설계 — `trcgg/loltrix_be`)
+>
+> **이 문서가 양 레포의 통신 계약(SoT)이다.**
+> 코드 내부 식별자가 이 문서와 다르면 코드가 잘못된 것이다.
+
+## 0. 목적
+
+백엔드(`loltrix_be`)와 MMR 계산 서비스(`gmok_mmr`)의 통신 계약 + MMR 서비스 내부 구조 확정.
+
+## 1. 아키텍처 결정 사항 (서비스 관점)
+
+| # | 항목 | 결정 |
+|---|---|---|
+| A | 운영 모드 | **별도 인스턴스에서 FastAPI 상시 가동.** 백엔드와 분리. |
+| B | 호출 패턴 | 백엔드에서 5분 주기 batch + 신규 구독 시 즉시 RECALC |
+| C | 단일 경기 API | **활성화.** 이게 일상 운영의 메인 경로 |
+| D | 포지션별 state | 백엔드가 보냄(`pre_match_user_summary`). MMR 서비스는 stateless |
+| E | 컬럼/식별자/enum | **백엔드 contract 기준으로 코드 내부까지 통일** (대규모 rename 필요) |
+| F | baseline 데이터 부족 | `INSUFFICIENT_DATA` 에러 응답 |
+| G | 산식 일관성 | 학습/적용 산식 통일 (RECALC도 `apply_*` 경로 사용) |
+| H | 의존성 | 런타임: pandas, numpy, scikit-learn, fastapi, uvicorn, psycopg2만 |
+
+## 2. 식별자 / Enum / 단위 (백엔드와 100% 동일)
+
+### 식별자
+| 항목 | 값 |
+|---|---|
+| 유저 식별자 | `puuid` |
+| 경기 식별자 | `custom_match_id` |
+| 길드 식별자 | `guild_id` |
+| 시즌 식별자 | `season` |
+| 계산 실행 식별자 | `calculation_id` |
+| baseline 식별자 | `baseline_version` |
+
+### Enum
+| 필드 | 값 |
+|---|---|
+| `position` | `TOP`, `JUG`, `MID`, `ADC`, `SUP` |
+| `game_team` | `blue`, `red` |
+| `game_result` | `1`(승), `0`(패) |
+
+## 3. 컬럼명 통일 (코드 rename 대상)
+
+MMR 서비스(`gmok_mmr`) 내부 코드가 사용하는 컬럼명을 백엔드 contract 기준으로 일괄 변경한다.
+
+| Before (현재 코드) | After (contract 기준) |
+|---|---|
+| `kills` | `kill` |
+| `deaths` | `death` |
+| `assists` | `assist` |
+| `game_duration` (분 단위 변환) | `time_played` (초) — 내부에서 사용 시 분 환산 헬퍼 사용 |
+| `cc_time` | `ccing` |
+| `damage_to_champions` | `total_damage_champions` |
+| `damage_taken` | `total_damage_taken` |
+| `damage_to_turrets` | `total_damage_dealt_to_buildings` |
+| `replay_code` | `custom_match_id` |
+| `BOTTOM` | `ADC` |
+| `MIDDLE` | `MID` |
+| `JUNGLE` | `JUG` |
+| `UTILITY` | `SUP` |
+| `gold_earned` | `gold` |
+| `pre_game_pos_mmr` | `pre_game_mmr` (응답) |
+| `pos_cumulative_mmr` | `post_game_mmr` (응답) |
+
+**산식은 변경하지 않는다.** 컬럼 alias만 바꾸는 작업.
+
+영향 파일(현재 구조 기준):
+- `src/mmr_refactor/features.py`
+- `src/mmr_refactor/silver.py`
+- `src/mmr_refactor/mmr.py`
+- `src/mmr_refactor/game_impact.py`
+- `src/mmr_refactor/baseline.py`
+- `src/mmr_refactor/service.py`
+- `src/mmr_refactor/api_server.py`
+- `tests/*` 전반
+
+`service.py`의 `_normalize_source_columns()`는 rename 완료 후 **제거 또는 idempotent guard로 축소**.
+
+## 4. Player-Game Payload (정식 계약)
+
+```json
+{
+  "custom_match_id": "CUSTOM-MATCH-260601-001",
+  "participant_id": 123,
+  "guild_id": "123456789",
+  "season": "2026",
+  "puuid": "puuid-000001",
+  "champion_id": "1",
+  "game_team": "blue",
+  "position": "TOP",
+  "game_result": 1,
+  "time_played": 1800,
+  "kill": 4,
+  "death": 2,
+  "assist": 6,
+  "gold": 12000,
+  "ccing": 20,
+  "exp": 15000,
+  "total_damage_champions": 23000,
+  "total_damage_dealt_to_buildings": 2500,
+  "total_damage_taken": 18000,
+  "vision_score": 25,
+  "vision_bought": 1,
+  "minions_killed": 180,
+  "neutral_minions_killed": 12,
+  "wards_placed": 8,
+  "wards_killed": 3,
+  "time_spent_dead": 120,
+  "heal_on_teammates": 0,
+  "shield_on_teammates": 0,
+  "feature_version": "2026-06",
+  "played_at": "2026-06-01T12:00:00Z"
+}
+```
+
+### 필수 필드
+`custom_match_id`, `participant_id`, `guild_id`, `season`, `puuid`, `champion_id`, `game_team`, `position`, `game_result`, `time_played`, `kill`, `death`, `assist`, `gold`, `ccing`, `exp`, `total_damage_champions`, `total_damage_taken`, `vision_score`, `played_at`
+
+### 권장 필드 (Game Impact 정확도 향상)
+`total_damage_dealt_to_buildings`, `vision_bought`, `minions_killed`, `neutral_minions_killed`, `wards_placed`, `wards_killed`, `time_spent_dead`, `heal_on_teammates`, `shield_on_teammates`, `feature_version`
+
+> 백엔드가 `is_mmr_eligible=false`인 경기는 전부 제외하고 보낸다. MMR 서비스는 받은 경기 전부 유효하다고 가정한다.
+
+## 5. API 1. Baseline 계산
+
+```http
+POST /v1/mmr/baselines/calculate
+```
+
+### Request
+```json
+{
+  "season": "2026",
+  "baseline_version": "2026-06",
+  "min_match_count": 200,
+  "matches": [ /* player-game row 배열 */ ]
+}
+```
+
+### Response (200)
+```json
+{
+  "season": "2026",
+  "baseline_version": "2026-06",
+  "mmr_baseline": {
+    "f1_mean": 1.0,
+    "f2_mean": 50.0
+  },
+  "game_impact_baseline": {
+    "position_weights": {
+      "TOP": { "kill": 0.12, "death": 0.08, ... },
+      "JUG": { ... },
+      "MID": { ... },
+      "ADC": { ... },
+      "SUP": { ... }
+    },
+    "outcome_stats": [
+      { "position": "TOP", "game_result": 1, "lower": 12.3, "upper": 87.5 },
+      { "position": "TOP", "game_result": 0, "lower":  8.1, "upper": 75.4 }
+    ]
+  },
+  "metadata": {
+    "match_count": 1000,
+    "player_game_row_count": 10000,
+    "calculated_at": "2026-06-01T00:00:00Z"
+  }
+}
+```
+
+### 에러
+경기 수 < `min_match_count`인 경우:
+```json
+{
+  "error_code": "INSUFFICIENT_DATA",
+  "message": "baseline requires at least 200 matches, got 47",
+  "details": { "received_match_count": 47, "required": 200 }
+}
+```
+HTTP 422.
+
+## 6. API 2. 전체 MMR 계산 (RECALC)
+
+```http
+POST /v1/mmr/recalculate
+```
+
+### Request
+```json
+{
+  "guild_id": "123456789",
+  "season": "2026",
+  "calculation_id": "MMR-20260601-0001",
+  "baseline_version": "2026-06",
+  "mmr_baseline": { "f1_mean": 1.0, "f2_mean": 50.0 },
+  "game_impact_baseline": { /* baseline 응답과 동일 구조 */ },
+  "matches": [ /* player-game row 배열, played_at asc 정렬됨 */ ]
+}
+```
+
+### Response
+```json
+{
+  "guild_id": "123456789",
+  "season": "2026",
+  "calculation_id": "MMR-20260601-0001",
+  "baseline_version": "2026-06",
+  "match_results": [
+    {
+      "custom_match_id": "CUSTOM-MATCH-260601-001",
+      "participant_id": 123,
+      "puuid": "puuid-000001",
+      "position": "TOP",
+      "game_result": 1,
+      "pre_game_mmr": 1300,
+      "expected_score": 0.5000,
+      "actual_score": 0.6200,
+      "relative_factor": 1.2400,
+      "personal_factor": 1.0800,
+      "final_factor": 1.1300,
+      "mmr_change": 23,
+      "post_game_mmr": 1323
+    }
+  ],
+  "user_summary": [
+    {
+      "puuid": "puuid-000001",
+      "total_mmr": 1323,
+      "total_games": 10,
+      "total_wins": 6,
+      "positions": [
+        { "position": "TOP", "pos_mmr": 1323, "pos_games": 10, "pos_wins": 6 }
+      ]
+    }
+  ],
+  "mmr_history": [
+    {
+      "puuid": "puuid-000001",
+      "custom_match_id": "CUSTOM-MATCH-260601-001",
+      "position": "TOP",
+      "history_type": "MATCH_RESULT",
+      "mmr_delta": 23,
+      "before_mmr": 1300,
+      "after_mmr": 1323,
+      "before_pos_mmr": 1300,
+      "after_pos_mmr": 1323,
+      "source_calculation_id": "MMR-20260601-0001",
+      "reason": "match result"
+    }
+  ],
+  "metadata": {
+    "match_count": 100,
+    "player_game_row_count": 1000,
+    "calculated_at": "2026-06-01T00:10:00Z"
+  }
+}
+```
+
+응답 크기가 큰 경우(`match_count > 1000`) 향후 NDJSON 스트리밍 도입 검토(v2).
+
+## 7. API 3. 단일 경기 MMR 계산 (Incremental — 메인 경로)
+
+```http
+POST /v1/mmr/matches/calculate
+```
+
+백엔드 5분 cron worker가 가장 자주 호출하는 API.
+
+### Request
+```json
+{
+  "guild_id": "123456789",
+  "season": "2026",
+  "calculation_id": "MMR-20260601-0002",
+  "custom_match_id": "CUSTOM-MATCH-260601-002",
+  "baseline_version": "2026-06",
+  "mmr_baseline": { "f1_mean": 1.0, "f2_mean": 50.0 },
+  "game_impact_baseline": { /* ... */ },
+  "match_rows": [ /* 정확히 10개 player-game row */ ],
+  "pre_match_user_summary": [
+    {
+      "puuid": "puuid-000001",
+      "positions": [
+        { "position": "TOP", "pos_mmr": 1300, "pos_games": 3, "pos_wins": 2 }
+      ]
+    }
+  ]
+}
+```
+
+`pre_match_user_summary`는 **이 경기 참가자 10명 전원**의 포지션별 현재 state. 누락된 참가자/포지션은 신규(`pos_mmr=1300, pos_games=0, pos_wins=0`)로 간주.
+
+### Response
+```json
+{
+  "guild_id": "123456789",
+  "season": "2026",
+  "calculation_id": "MMR-20260601-0002",
+  "custom_match_id": "CUSTOM-MATCH-260601-002",
+  "baseline_version": "2026-06",
+  "match_results": [ /* RECALC와 동일 구조, 길이 10 */ ],
+  "updated_user_summary": [
+    {
+      "puuid": "puuid-000001",
+      "total_mmr": 1323,
+      "total_games": 4,
+      "total_wins": 3,
+      "positions": [
+        { "position": "TOP", "pos_mmr": 1323, "pos_games": 4, "pos_wins": 3 }
+      ]
+    }
+  ],
+  "mmr_history": [ /* RECALC와 동일 구조 */ ],
+  "metadata": {
+    "calculated_at": "2026-06-01T00:20:00Z",
+    "mode": "incremental"
+  }
+}
+```
+
+## 8. 입력 검증 규칙
+
+각 `custom_match_id`는 반드시:
+- 정확히 10개 player-game row
+- 포지션별 정확히 2개 row (TOP × 2, JUG × 2, ...)
+- 각 (custom_match_id, position) 조합마다 winner 1명 / loser 1명
+- 같은 경기 내 `puuid` 중복 없음
+- `position`, `game_team`, `game_result` 모두 정의된 enum 값
+
+검증 실패 시 HTTP 400 + 에러 코드.
+
+## 9. 에러 코드 (확정)
+
+| HTTP | 코드 | 의미 |
+|---|---|---|
+| 400 | `MISSING_REQUIRED_COLUMN` | 필수 컬럼 누락 |
+| 400 | `INVALID_MATCH_STRUCTURE` | 경기 row/포지션/승패 구조 오류 |
+| 400 | `INVALID_POSITION` | enum 외 포지션 |
+| 400 | `INVALID_GAME_TEAM` | enum 외 팀 |
+| 400 | `INVALID_GAME_RESULT` | enum 외 승패 |
+| 400 | `INVALID_BASELINE` | baseline 누락/형식 오류 |
+| 400 | `INSUFFICIENT_USER_STATE` | 단일 경기 계산에 필요한 pre summary 부족 |
+| 422 | `INSUFFICIENT_DATA` | baseline 계산용 데이터 부족 |
+| 500 | `CALCULATION_FAILED` | 내부 계산 예외 |
+
+응답 포맷:
+```json
+{
+  "error_code": "INVALID_MATCH_STRUCTURE",
+  "message": "each custom_match_id must contain 10 rows",
+  "details": { "invalid_custom_match_ids": ["..."] }
+}
+```
+
+## 10. MMR 산식 (v1 확정)
+
+### 10.1 기본 설정
+```python
+INITIAL_MMR = 1300
+BASE_WIN = 20
+BASE_LOSS = -15
+MMR_MIN_CHANGE = -25
+MMR_MAX_CHANGE = 30
+MMR_K_DECAY_START = 1500
+MMR_K_DECAY_RATE = 0.002
+MMR_K_MIN = 0.35
+ALPHA = 0.6   # 개인 기여도
+BETA  = 0.4   # 상대 비교
+GAMMA = 0.2   # ELO 기대 대비 실제
+WIN_FLOOR  = +12   # 의도된 floor (내전 변동 최소값)
+LOSS_FLOOR = -12   # 의도된 floor
+```
+
+WIN/LOSS floor 12/-12는 의도된 정책이다. 내전 특성상 변동이 너무 작으면 사용자가 체감 못함. 향후 조정 시 이 문서에서 명시.
+
+### 10.2 계산 순서 (각 경기당)
+1. 경기 시작 시점의 (puuid, position)별 pre_pos_mmr snapshot
+2. 각 row마다:
+   - 같은 포지션 상대(opponent) pos_mmr 조회
+   - `expected_score = 1 / (1 + 10^((opp_mmr - my_mmr)/400))`
+   - `actual_score = game_impact_vs_opponent / 100` (NaN이면 expected)
+   - `relative_factor = actual / expected` (clip 0.5~2 후 가져옴)
+   - `personal_factor = (f1^ALPHA) * (f2^BETA)`
+     - `f1 = game_n_person_contribution / mmr_baseline.f1_mean`
+     - `f2 = game_impact_vs_opponent / mmr_baseline.f2_mean`
+     - 각 [0.5, 2] clip
+   - `final_factor = personal_factor * relative_factor^GAMMA`
+   - `k = max(K_MIN, 1 - max(0, (current_mmr - K_DECAY_START) * K_DECAY_RATE))`
+   - 승: `delta = clip(max(BASE_WIN * final_factor * k, WIN_FLOOR), WIN_FLOOR, MAX_CHANGE)`
+   - 패: `delta = clip(min(BASE_LOSS * final_factor * k, LOSS_FLOOR), MIN_CHANGE, LOSS_FLOOR)`
+3. `post_pos_mmr = pre_pos_mmr + delta`
+4. `total_mmr`은 (포지션별 pos_mmr × pos_games) / Σpos_games 가중 평균
+
+### 10.3 산식 일관성 (RECALC ↔ Incremental)
+RECALC도 incremental과 동일하게 **저장된 `game_impact_baseline`을 `apply_game_impact_baseline`으로 적용**해야 한다. 즉 RECALC도 baseline 입력이 필수다.
+
+- ❌ "데이터 들어왔으니 RandomForest를 다시 학습해서 적용"
+- ✅ "BASELINE job에서 학습한 position_weights/outcome_stats를 그대로 RECALC에 적용"
+
+이 일관성이 깨지면 RECALC 직후와 incremental 누적 결과가 다르게 나옴(현재 코드의 잠재 버그).
+
+## 11. Baseline 산정 정책
+
+### 11.1 산정 시점
+| 시점 | 트리거 |
+|---|---|
+| 시즌 시작 | 백엔드가 BASELINE job 생성 → 운영자 승인/자동 |
+| 운영자 갱신 | `/admin/mmr/baseline` |
+| **매 incremental마다는 갱신하지 않는다.** | |
+
+### 11.2 데이터 부족 처리
+- 최소 경기 수 (기본 200) 미달 → `INSUFFICIENT_DATA` 422 응답
+- 백엔드는 해당 시즌의 `guild_mmr_state.status = error` 또는 `wait_init` 유지 + 관리자 알람
+
+### 11.3 baseline payload 구조 안정성
+- `mmr_baseline`: `{ f1_mean, f2_mean }` (현재 v1) — 향후 확장 가능하되 키 추가만, 제거 금지
+- `game_impact_baseline.position_weights`: `{ position: { metric: weight } }` 중첩 dict
+- `game_impact_baseline.outcome_stats`: `[ { position, game_result, lower, upper } ]` 배열
+
+## 12. MMR 서비스 내부 구조 (현재 코드 → 목표)
+
+### 12.1 모듈 책임 (rename 후 동일)
+```
+src/mmr_refactor/
+├── api_server.py        FastAPI 진입점 — endpoint 3개
+├── service.py           HTTP layer ↔ pandas pipeline 어댑터
+├── silver.py            기본 정제 (이름은 유지, 의미는 동일)
+├── features.py          파생 feature 생성 (BASE_METRICS는 contract 컬럼 기반)
+├── game_impact.py       Game Impact 계산 (RF 학습은 baseline에서만)
+├── baseline.py          Baseline 산출/직렬화
+├── mmr.py               ELO 기반 MMR 갱신
+├── data_loader.py       (선택) DB→DF 로더
+└── data_writer.py       (선택) DF→DB 라이터
+```
+
+### 12.2 변경 필요한 부분 (코드 작업 시 가이드)
+
+1. **모든 컬럼명을 3장 표대로 일괄 rename**
+2. `mmr.py:_apply_mmr_game`의 응답 컬럼명을 `pre_game_mmr`, `post_game_mmr`로
+3. `service.calculate_full_mmr` → baseline 필수 인자로 강제 (None 경로 제거)
+4. `service.calculate_single_match_mmr` → request key를 `mmr_baseline`, `pre_match_user_summary`로
+5. `service._runtime_state_from_payload` → `pre_match_user_summary` 포맷에 맞춰 다시 작성
+6. `game_impact.compute_raw_game_impact` 벡터화 (`df[metrics].values @ weights_matrix`)
+7. `features.add_basic_features`의 NaN→0 fillna 제거 또는 metric별 정책 명시
+8. `features.BASE_METRICS` 재정의 (분당 metric은 `time_played / 60`으로 계산)
+9. `silver.clean_match_data`의 `game_duration` 처리 제거 (이제 `time_played` 사용)
+
+### 12.3 응답에 `match_results` 외 포함되어야 할 것
+- `user_summary` (RECALC) / `updated_user_summary` (incremental): **포지션별 포함 필수**
+- `mmr_history`: 백엔드 저장용. position, before/after_pos_mmr 모두 포함
+
+## 13. 배포 / 운영
+
+### 13.1 인스턴스
+- 별도 인스턴스 (Lightsail 2GB 권장, 처음엔 1GB 가능)
+- FastAPI + uvicorn (`--workers 1`, `--limit-max-requests 200`)
+- 메모리 사용량 모니터: baseline 학습 시점에 스파이크 ↑
+
+### 13.2 런타임 의존성
+```
+fastapi>=0.110
+uvicorn[standard]>=0.27
+pandas>=2.0
+numpy>=1.24
+scikit-learn>=1.3
+psycopg2-binary>=2.9   # (DB 모드 사용 시)
+python-dotenv>=1.0
+```
+
+`matplotlib`, `seaborn`, `statsmodels`, `koreanize-matplotlib`, `openpyxl`은 **런타임에서 제거**.
+필요 시 `requirements-dev.txt` 분리.
+
+### 13.3 헬스체크
+- `GET /health` → 200 OK, payload `{ "status": "ok", "version": "...", "uptime_seconds": ... }`
+- 백엔드 worker에서 매 incremental 호출 전에 사전 ping (선택)
+
+### 13.4 인증 (서비스 간)
+- 백엔드 ↔ MMR 서비스 통신은 내부망 가정. 그래도 정적 헤더 시크릿 1개 권장.
+- `Authorization: Bearer <SERVICE_TOKEN>` 또는 `X-Service-Secret: ...`
+
+## 14. 통합 테스트 (양 레포 공통)
+
+**같은 JSON pair**를 양쪽 CI에 박는다.
+
+```
+fixtures/
+  baseline_calculate_request.json
+  baseline_calculate_response.json
+  recalculate_request.json
+  recalculate_response.json
+  matches_calculate_request.json
+  matches_calculate_response.json
+```
+
+- 백엔드: payload 빌더 결과 == `*_request.json` 단언
+- MMR 서비스: `*_request.json` 입력 시 응답이 `*_response.json` schema 부합 단언
+
+이 fixture는 양 레포에서 동일 파일을 유지(서브모듈 또는 복사 + CI 동기 체크).
+
+## 15. 마이그레이션 / 작업 순서 (MMR 서비스 측)
+
+1. 3장 컬럼명 일괄 rename + 테스트 통과
+2. `MMRSettings.positions`를 `("TOP", "JUG", "MID", "ADC", "SUP")`로 변경
+3. 응답 컬럼명 변경 (`pre_game_mmr`, `post_game_mmr`)
+4. `service.calculate_single_match_mmr` request schema 변경 + `pre_match_user_summary` 처리
+5. `user_summary` / `updated_user_summary` 응답에 포지션별 항목 추가
+6. baseline `INSUFFICIENT_DATA` 422 응답 도입
+7. RECALC에서 baseline 필수화 (None 경로 제거)
+8. `compute_raw_game_impact` 벡터화
+9. requirements 슬림화
+10. `/health` 응답 보강
+11. fixture pair 추가 + CI 연결
+12. (선택) 응답 NDJSON 스트리밍 v2 검토
+
+## 16. 책임 정리 (양 레포)
+
+### 백엔드 책임 (이 문서 외 `MMR_BACKEND_DESIGN.md` 참고)
+- 리플레이 → metric 정제
+- `is_mmr_eligible` 판정
+- baseline 저장 / active baseline 관리
+- MMR 서비스 호출
+- 결과 저장 (`match_mmr_result`, `mmr_history`, `player_mmr_summary`)
+- job queue / worker
+- 소프트 딜리트 / cleanup
+
+### MMR 서비스 책임 (이 문서)
+- payload 검증
+- Game Impact / baseline 계산
+- 단일 경기 incremental 계산
+- 전체 RECALC 계산
+- `mmr_history` 항목 생성 (저장은 백엔드)
+- DB 직접 접근 없음 (백엔드가 모든 데이터 주입)
+
+## 17. 비기능 요구
+
+| 항목 | 목표 |
+|---|---|
+| 단일 경기 응답 시간 | < 500ms (p95) |
+| RECALC 응답 (1000경기) | < 30s (p95) |
+| baseline 계산 (5000경기) | < 60s |
+| 메모리 사용 (idle) | < 250MB |
+| 메모리 사용 (RECALC) | < 800MB |
+| 가용성 | 99% (월 ~7시간 다운타임 허용) |
+
+## 18. 향후 (v2 후보, 현재 결정 보류)
+
+- 응답 NDJSON 스트리밍
+- 포지션별 가중치 자동 업데이트 (현재는 baseline 갱신 시에만)
+- 챔피언 보정 factor
+- 다중 worker / 큐 시스템 (Celery 등)


### PR DESCRIPTION
## Summary
This PR adds comprehensive design documentation for the MMR (Matchmaking Rating) service integration between the backend (`loltrix_be`) and the MMR calculation service (`gmok_mmr`). These documents establish the formal contract and architecture for the entire MMR system.

## Key Changes

### MMR Service Design (`docs/MMR_SERVICE_DESIGN.md`)
- **Architecture decisions**: Defines MMR service as a separate FastAPI instance with incremental calculation as the primary path
- **Data contract**: Establishes unified identifiers, enums, and column naming conventions (e.g., `kill`/`death`/`assist` instead of `kills`/`deaths`/`assists`)
- **API specifications**: Documents three endpoints:
  - `POST /v1/mmr/baselines/calculate` - Baseline computation
  - `POST /v1/mmr/recalculate` - Full MMR recalculation
  - `POST /v1/mmr/matches/calculate` - Single-match incremental calculation (primary path)
- **MMR formula**: Specifies v1 calculation algorithm with K-decay, personal/relative factors, and floor constraints
- **Input validation**: Defines strict match structure requirements (10 rows, 2 per position, winner/loser per position)
- **Error handling**: Establishes error codes and response formats (e.g., `INSUFFICIENT_DATA` for baseline shortfall)
- **Internal refactoring**: Lists required code changes including column renames across all modules

### Backend Design (`docs/MMR_BACKEND_DESIGN.md`)
- **Architecture decisions**: Incremental-first approach with RECALC reserved for init/season change/recovery
- **State management**: Defines status enums for subscriptions, MMR state, jobs, and match processing
- **Database schema**: Specifies 9 new/modified tables:
  - `guild_subscription` - Service subscription tracking
  - `guild_mmr_state` - Per-guild/season MMR readiness state
  - `mmr_baseline` - Baseline storage with active version management
  - `mmr_job` - Job queue with retry logic
  - `custom_match_mmr_status` - Match-level processing status
  - `match_participant_metric` - Unified stats/MMR input
  - `match_mmr_result` - Calculation results
  - `mmr_history` - Monthly partitioned audit trail
  - `player_mmr_summary` - Current MMR with position-specific columns
- **Workflows**: Documents 5-minute incremental worker, new subscription init, RECALC triggers, and daily consistency checks
- **Operational policies**: Soft delete with 30-day restore window, baseline data sufficiency checks, eligibility filtering
- **Concurrency**: Advisory locks and SKIP LOCKED for safe multi-worker operation
- **Capacity planning**: Targets 20 guilds, 200 daily matches, ~730k annual history rows

## Notable Implementation Details

1. **Contract as Source of Truth**: Backend column/enum naming is the canonical reference; MMR service code must align exactly
2. **Stateless MMR Service**: All player state provided by backend in `pre_match_user_summary`; service performs no persistence
3. **Incremental Consistency**: RECALC uses the same `apply_game_impact_baseline` path as incremental to prevent divergence
4. **Position-Specific State**: `player_mmr_summary` includes per-position MMR/games/wins to enable incremental calculations
5. **Eligibility Filtering**: Backend marks ineligible matches (`is_mmr_eligible=false`); entire match excluded if any participant ineligible
6. **Baseline Versioning**: Active baseline per season; insufficient data returns explicit 422 error rather than fallback
7. **Unified Identifiers**: `puuid`, `custom_match_id`, `guild_id`, `season`, `calculation_id`, `baseline_version` used consistently across both systems

These documents serve as the binding contract between the two repositories and should be referenced during implementation of both the MMR service refactor and backend integration.

https://claude.ai/code/session_01H2czUuXf2wioQ2KfVafgpt